### PR TITLE
fix: Windows compatibility + honor UI-selected Claude model

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,9 @@ npm run serve:bridge
 | `--default-allowed-tools` | `ADAPTER_DEFAULT_ALLOWED_TOOLS` | Tools always auto-allowed (comma-separated). Default: `WebFetch,WebSearch`. |
 | `--setting-sources` | `ADAPTER_SETTING_SOURCES` | Claude settings sources: `user`, `project`, `local` (comma-separated). Default: `project,local`. |
 | `--append-system-prompt` | `ADAPTER_APPEND_SYSTEM_PROMPT` | Inline overlay prompt text. |
-| `--append-system-prompt-file` | `ADAPTER_APPEND_SYSTEM_PROMPT_FILE` | File-based overlay prompt. |
-| `--forward-frontend-model` | `ADAPTER_FORWARD_FRONTEND_MODEL` | Pass frontend `metadata.model` to runtime (default `true`). |
+| `--append-system-prompt-file` | `ADAPTER_APPEND_SYSTEM_PROMPT_FILE` | File-based overlay prompt. Missing optional files are ignored. |
+| `--forward-frontend-model` | `ADAPTER_FORWARD_FRONTEND_MODEL` | Pass frontend `metadata.model` to runtime (default `true`). Generic aliases like `opus`, `sonnet`, and `haiku` are forwarded when the SDK accepts them. |
+| `--log-file` | `ADAPTER_LOG_FILE` | Mirror bridge stdout/stderr to a file. Use `1` / `true` to write to `<state-dir>/bridge.log`. |
 
 Default additional readable directories:
 
@@ -252,9 +253,13 @@ That usually means one of these layers is wrong:
 
 ### Logs
 
+Daemon logs on macOS still live under:
+
 ```bash
 ~/Library/Logs/cc-llm4zotero-adapter/
 ```
+
+If the bridge is started without an attached terminal and you also want a plain bridge process log, set `ADAPTER_LOG_FILE=1` (or pass `--log-file`) to mirror stdout/stderr into `<state-dir>/bridge.log`.
 
 ## Repository Layout
 

--- a/bin/start-bridge-server.ts
+++ b/bin/start-bridge-server.ts
@@ -8,10 +8,58 @@ import {
 } from "../src/index.js";
 import { resolveLegacyAdapterPaths } from "../src/zotero-profile-paths.js";
 import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { resolve } from "node:path";
+
+function installFileLogger(filePath: string): void {
+  try {
+    mkdirSync(resolve(filePath, ".."), { recursive: true });
+    const stream = createWriteStream(filePath, { flags: "a" });
+    const origLog = console.log.bind(console);
+    const origErr = console.error.bind(console);
+    const write = (level: string, args: unknown[]): void => {
+      try {
+        const line =
+          `${new Date().toISOString()} [${level}] ` +
+          args
+            .map((a) =>
+              typeof a === "string"
+                ? a
+                : (() => {
+                    try {
+                      return JSON.stringify(a);
+                    } catch {
+                      return String(a);
+                    }
+                  })(),
+            )
+            .join(" ") +
+          "\n";
+        stream.write(line);
+      } catch {
+        // ignore
+      }
+    };
+    console.log = (...args: unknown[]) => {
+      write("log", args);
+      origLog(...args);
+    };
+    console.error = (...args: unknown[]) => {
+      write("err", args);
+      origErr(...args);
+    };
+  } catch {
+    // ignore
+  }
+}
 
 function getArg(name: string): string | undefined {
   const flag = `--${name}`;
@@ -84,6 +132,8 @@ function readTextFile(path: string | undefined): string {
   try {
     return readFileSync(path, "utf8").trim();
   } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") return "";
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read file: ${path} (${message})`);
   }
@@ -152,6 +202,16 @@ async function main() {
 
   mkdirSync(runtimeCwd, { recursive: true });
   mkdirSync(stateDirResolved, { recursive: true });
+  const rawLogFileSetting =
+    getArg("log-file") ?? process.env.ADAPTER_LOG_FILE ?? "";
+  const logFileSetting = rawLogFileSetting.trim();
+  if (logFileSetting) {
+    const resolvedLogPath =
+      ["1", "true", "yes", "on"].includes(logFileSetting.toLowerCase())
+        ? resolve(stateDirResolved, "bridge.log")
+        : resolve(logFileSetting);
+    installFileLogger(resolvedLogPath);
+  }
   const projectClaudeDir = resolve(runtimeCwd, ".claude");
   const projectSettingsFile = resolve(projectClaudeDir, "settings.json");
   mkdirSync(projectClaudeDir, { recursive: true });

--- a/bin/start-bridge-server.ts
+++ b/bin/start-bridge-server.ts
@@ -8,9 +8,59 @@ import {
 } from "../src/index.js";
 import { resolveLegacyAdapterPaths } from "../src/zotero-profile-paths.js";
 import type { SettingSource } from "@anthropic-ai/claude-agent-sdk";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { resolve } from "node:path";
+
+// Tee console.log / console.error to a log file so output survives even when
+// the bridge is spawned without an attached terminal (e.g. by the Zotero
+// plugin via Subprocess.call). The target path is derived below once we know
+// the state dir.
+function installFileLogger(filePath: string): void {
+  try {
+    mkdirSync(resolve(filePath, ".."), { recursive: true });
+    const stream = createWriteStream(filePath, { flags: "a" });
+    const origLog = console.log.bind(console);
+    const origErr = console.error.bind(console);
+    const write = (level: string, args: unknown[]): void => {
+      try {
+        const line =
+          `${new Date().toISOString()} [${level}] ` +
+          args
+            .map((a) =>
+              typeof a === "string" ? a : (() => {
+                try {
+                  return JSON.stringify(a);
+                } catch {
+                  return String(a);
+                }
+              })(),
+            )
+            .join(" ") +
+          "\n";
+        stream.write(line);
+      } catch {
+        // ignore
+      }
+    };
+    console.log = (...args: unknown[]) => {
+      write("log", args);
+      origLog(...args);
+    };
+    console.error = (...args: unknown[]) => {
+      write("err", args);
+      origErr(...args);
+    };
+  } catch {
+    // ignore
+  }
+}
 
 function getArg(name: string): string | undefined {
   const flag = `--${name}`;
@@ -83,6 +133,10 @@ function readTextFile(path: string | undefined): string {
   try {
     return readFileSync(path, "utf8").trim();
   } catch (error) {
+    // Missing optional files (e.g. CLAUDE.md, append-system-prompt-file) must
+    // not prevent the bridge from starting. Only surface non-ENOENT errors.
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") return "";
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read file: ${path} (${message})`);
   }
@@ -150,6 +204,20 @@ async function main() {
 
   mkdirSync(runtimeCwd, { recursive: true });
   mkdirSync(stateDirResolved, { recursive: true });
+  // Opt-in diagnostic log file. Set ADAPTER_LOG_FILE to any path (absolute or
+  // relative to cwd) to enable, or "1"/"true" to write to <stateDir>/bridge.log.
+  // Useful when the bridge is spawned without an attached terminal (e.g. via
+  // Zotero's Subprocess API), which otherwise drops all stdout/stderr output.
+  const rawLogFileSetting =
+    getArg("log-file") ?? process.env.ADAPTER_LOG_FILE ?? "";
+  const logFileSetting = rawLogFileSetting.trim();
+  if (logFileSetting) {
+    const resolvedLogPath =
+      ["1", "true", "yes", "on"].includes(logFileSetting.toLowerCase())
+        ? resolve(stateDirResolved, "bridge.log")
+        : resolve(logFileSetting);
+    installFileLogger(resolvedLogPath);
+  }
   const projectClaudeDir = resolve(runtimeCwd, ".claude");
   const projectSettingsFile = resolve(projectClaudeDir, "settings.json");
   mkdirSync(projectClaudeDir, { recursive: true });

--- a/src/bridge/claude-code-runtime-adapter.ts
+++ b/src/bridge/claude-code-runtime-adapter.ts
@@ -97,6 +97,23 @@ export class ClaudeCodeRuntimeAdapter {
     }
   }
 
+  private buildSessionMapKey(requestOrConversationKey: RunTurnRequest | string): string {
+    if (typeof requestOrConversationKey === "string") {
+      return requestOrConversationKey;
+    }
+    const metadata =
+      requestOrConversationKey.metadata && typeof requestOrConversationKey.metadata === "object"
+        ? (requestOrConversationKey.metadata as Record<string, unknown>)
+        : {};
+    const providerIdentity =
+      typeof metadata.providerIdentity === "string" && metadata.providerIdentity.trim()
+        ? metadata.providerIdentity.trim()
+        : "";
+    return providerIdentity
+      ? `${requestOrConversationKey.conversationKey}::provider:${providerIdentity}`
+      : requestOrConversationKey.conversationKey;
+  }
+
   async getMappedProviderSessionId(conversationKey: string): Promise<string | undefined> {
     return this.sessionMapper.get(conversationKey);
   }
@@ -109,6 +126,14 @@ export class ClaudeCodeRuntimeAdapter {
     await this.runtimeClient.releaseHotRuntime?.(conversationKey, mountId);
   }
 
+  private extractProviderIdentity(request: RunTurnRequest): string {
+    const metadata =
+      request.metadata && typeof request.metadata === "object"
+        ? (request.metadata as Record<string, unknown>)
+        : {};
+    return typeof metadata.providerIdentity === "string" ? metadata.providerIdentity.trim() : "";
+  }
+
   async runTurn(request: RunTurnRequest, hooks: RunTurnHooks = {}): Promise<RunTurnOutcome> {
     const signal = hooks.signal ?? request.signal;
     const forceFreshSession = Boolean(
@@ -116,16 +141,56 @@ export class ClaudeCodeRuntimeAdapter {
         typeof request.metadata === "object" &&
         (request.metadata as Record<string, unknown>).forceFreshSession === true,
     );
+    const sessionMapKey = this.buildSessionMapKey(request);
     const initialSessionId = forceFreshSession
       ? undefined
-      : await this.sessionMapper.get(request.conversationKey);
+      : await this.sessionMapper.get(sessionMapKey);
+    const metadata =
+      request.metadata && typeof request.metadata === "object"
+        ? (request.metadata as Record<string, unknown>)
+        : {};
+    const autoCompactEligible = metadata.claudeAutoCompactEligible === true;
+    const rawThreshold = Number(metadata.claudeAutoCompactThresholdPercent);
+    const estimatedContextTokens = Math.max(0, Number(metadata.claudeEstimatedContextTokens) || 0);
+    const shouldPreCompact =
+      autoCompactEligible &&
+      !/^\/compact(?:\s|$)/i.test(request.userMessage.trim()) &&
+      Number.isFinite(rawThreshold) &&
+      (Math.max(0, Math.min(99, Math.round(rawThreshold))) === 0
+        ? estimatedContextTokens > 0
+        : estimatedContextTokens > 0 && estimatedContextTokens / 200_000 >= rawThreshold / 100);
+
+    let providerSessionId = initialSessionId;
+    if (shouldPreCompact) {
+      await hooks.onEvent?.({
+        type: "status",
+        ts: Date.now(),
+        payload: {
+          text: "Compacting context…",
+        },
+      });
+      const compactRequest: RunTurnRequest = {
+        ...request,
+        userMessage: "/compact",
+        metadata: {
+          ...metadata,
+          claudeAutoCompactEligible: false,
+        },
+      };
+      const compactOutcome = await this.runTurnOnce(compactRequest, hooks, signal, providerSessionId);
+      providerSessionId = compactOutcome.providerSessionId ?? providerSessionId;
+      if (compactOutcome.status !== "completed") {
+        return compactOutcome;
+      }
+    }
+
     let firstOutcome: RunTurnOutcome;
     try {
-      firstOutcome = await this.runTurnOnce(request, hooks, signal, initialSessionId);
+      firstOutcome = await this.runTurnOnce(request, hooks, signal, providerSessionId);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      if (initialSessionId && this.isInvalidThinkingSignatureError(err.message)) {
-        await this.sessionMapper.delete(request.conversationKey);
+      if (providerSessionId && this.isInvalidThinkingSignatureError(err.message)) {
+        await this.sessionMapper.delete(sessionMapKey);
         await hooks.onEvent?.({
           type: "status",
           ts: Date.now(),
@@ -137,8 +202,8 @@ export class ClaudeCodeRuntimeAdapter {
       }
       throw err;
     }
-    if (this.shouldRetryForThinkingSignature(initialSessionId, firstOutcome)) {
-      await this.sessionMapper.delete(request.conversationKey);
+    if (this.shouldRetryForThinkingSignature(providerSessionId, firstOutcome)) {
+      await this.sessionMapper.delete(sessionMapKey);
       await hooks.onEvent?.({
         type: "status",
         ts: Date.now(),
@@ -147,6 +212,22 @@ export class ClaudeCodeRuntimeAdapter {
         },
       });
       firstOutcome = await this.runTurnOnce(request, hooks, signal, undefined);
+    }
+    if (
+      providerSessionId &&
+      firstOutcome.providerSessionId &&
+      firstOutcome.providerSessionId !== providerSessionId &&
+      this.extractProviderIdentity(request)
+    ) {
+      await this.sessionMapper.delete(sessionMapKey);
+      await hooks.onEvent?.({
+        type: "status",
+        ts: Date.now(),
+        payload: {
+          text: "Claude runtime changed. Rebuilding this conversation on the new runtime while keeping local context.",
+        },
+      });
+      return this.runTurnOnce(request, hooks, signal, undefined);
     }
     return firstOutcome;
   }
@@ -157,6 +238,7 @@ export class ClaudeCodeRuntimeAdapter {
     signal: AbortSignal | undefined,
     providerSessionId: string | undefined,
   ): Promise<RunTurnOutcome> {
+    const sessionMapKey = this.buildSessionMapKey(request);
     const stream = await this.runtimeClient.startTurn({
       conversationKey: request.conversationKey,
       userMessage: request.userMessage,
@@ -170,7 +252,7 @@ export class ClaudeCodeRuntimeAdapter {
     let resolvedSessionId = providerSessionId;
     if (stream.providerSessionId) {
       resolvedSessionId = stream.providerSessionId;
-      await this.sessionMapper.set(request.conversationKey, stream.providerSessionId);
+      await this.sessionMapper.set(sessionMapKey, stream.providerSessionId);
     }
 
     hooks.onStart?.({
@@ -221,7 +303,7 @@ export class ClaudeCodeRuntimeAdapter {
           event.type === "final";
         if (canAdoptSessionId && eventSessionId && eventSessionId !== resolvedSessionId) {
           resolvedSessionId = eventSessionId;
-          await this.sessionMapper.set(request.conversationKey, eventSessionId);
+          await this.sessionMapper.set(sessionMapKey, eventSessionId);
         }
         if (event.type === "message_delta") {
           const delta = event.payload.delta;

--- a/src/bridge/llm4zotero-contract.ts
+++ b/src/bridge/llm4zotero-contract.ts
@@ -28,6 +28,20 @@ export type Llm4ZoteroAgentEvent =
     }
   | { type: "message_delta"; text: string }
   | { type: "message_rollback"; length: number; text: string }
+  | {
+      type: "usage";
+      inputTokens: number;
+      outputTokens: number;
+      cacheCreationInputTokens?: number;
+      cacheReadInputTokens?: number;
+      contextTokens: number;
+      contextWindow?: number;
+      contextWindowIsAuthoritative?: boolean;
+      percentage?: number;
+      sessionId?: string;
+      model?: string;
+    }
+  | { type: "context_compacted"; automatic?: boolean }
   | { type: "fallback"; reason: string }
   | { type: "final"; text: string };
 

--- a/src/event-mapper/map-provider-event.ts
+++ b/src/event-mapper/map-provider-event.ts
@@ -12,6 +12,8 @@ const SUPPORTED_TYPES = new Set([
   "confirmation_resolved",
   "message_delta",
   "message_rollback",
+  "usage",
+  "context_compacted",
   "final"
 ]);
 

--- a/src/event-mapper/map-sdk-message.ts
+++ b/src/event-mapper/map-sdk-message.ts
@@ -14,6 +14,11 @@ interface ClaudeContentBlock {
 
 interface MessageContainer {
   content?: ClaudeContentBlock[];
+  usage?: Record<string, unknown>;
+}
+
+interface ModelUsageEntry {
+  contextWindow?: unknown;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -25,6 +30,66 @@ function getSessionId(msg: unknown): string | undefined {
   if (typeof record.sessionId === "string" && record.sessionId.trim()) return record.sessionId.trim();
   if (typeof record.session_id === "string" && record.session_id.trim()) return record.session_id.trim();
   return undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeUsagePayload(args: {
+  usage?: Record<string, unknown> | undefined;
+  modelUsage?: Record<string, ModelUsageEntry> | undefined;
+  sessionId?: string;
+}): ProviderEvent | null {
+  const inputTokens = asFiniteNumber(args.usage?.input_tokens) ?? asFiniteNumber(args.usage?.inputTokens) ?? 0;
+  const outputTokens = asFiniteNumber(args.usage?.output_tokens) ?? asFiniteNumber(args.usage?.outputTokens) ?? 0;
+  const cacheCreationInputTokens =
+    asFiniteNumber(args.usage?.cache_creation_input_tokens) ??
+    asFiniteNumber(args.usage?.cacheCreationInputTokens) ??
+    0;
+  const cacheReadInputTokens =
+    asFiniteNumber(args.usage?.cache_read_input_tokens) ??
+    asFiniteNumber(args.usage?.cacheReadInputTokens) ??
+    0;
+  const contextTokens = Math.max(0, inputTokens + cacheCreationInputTokens + cacheReadInputTokens);
+
+  let model: string | undefined;
+  let contextWindow: number | undefined;
+  const modelUsageEntries = args.modelUsage ? Object.entries(args.modelUsage) : [];
+  if (modelUsageEntries.length === 1) {
+    const [modelName, entry] = modelUsageEntries[0]!;
+    model = modelName || undefined;
+    contextWindow = asFiniteNumber(entry?.contextWindow);
+  }
+
+  if (
+    contextTokens <= 0 &&
+    !(typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0)
+  ) {
+    return null;
+  }
+
+  const percentage =
+    typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0
+      ? Math.max(0, Math.min(100, Math.round((contextTokens / contextWindow) * 100)))
+      : undefined;
+
+  return {
+    type: "usage",
+    payload: {
+      inputTokens,
+      outputTokens,
+      cacheCreationInputTokens,
+      cacheReadInputTokens,
+      contextTokens,
+      contextWindow,
+      contextWindowIsAuthoritative:
+        typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0,
+      percentage,
+      sessionId: args.sessionId,
+      model,
+    },
+  };
 }
 
 function normalizeToolResultContent(content: unknown): string {
@@ -162,6 +227,20 @@ export function mapSdkMessageToProviderEvents(raw: unknown): ProviderEvent[] {
     const events: ProviderEvent[] = [providerEvent];
     const message = asRecord(msg.message) as MessageContainer;
     const contentBlocks = Array.isArray(message.content) ? message.content : [];
+     const parentToolUseId =
+      (typeof msg.parent_tool_use_id === "string" && msg.parent_tool_use_id.trim())
+        ? msg.parent_tool_use_id.trim()
+        : null;
+    const usageEvent =
+      parentToolUseId === null
+        ? normalizeUsagePayload({
+            usage: message.usage,
+            sessionId,
+          })
+        : null;
+    if (usageEvent) {
+      events.push(usageEvent);
+    }
     const hasText = contentBlocks.some((block) => block.type === "text" && typeof block.text === "string");
     const hasToolUse = contentBlocks.some((block) => block.type === "tool_use");
     for (const block of contentBlocks) {
@@ -225,24 +304,44 @@ export function mapSdkMessageToProviderEvents(raw: unknown): ProviderEvent[] {
 
   if (type === "result") {
     const output = extractResultOutput(msg);
-    return [
-      providerEvent,
-      {
-        type: "final",
-        payload: {
-          output,
-          isError: Boolean(msg.is_error),
-          subtype: msg.subtype,
-          durationMs: msg.duration_ms,
-          numTurns: msg.num_turns,
-          sessionId
-        }
+    const events: ProviderEvent[] = [providerEvent];
+    const usageEvent = normalizeUsagePayload({
+      modelUsage: asRecord(msg.modelUsage) as Record<string, ModelUsageEntry> | undefined,
+      sessionId,
+    });
+    if (usageEvent) {
+      events.push(usageEvent);
+    }
+    events.push({
+      type: "final",
+      payload: {
+        output,
+        isError: Boolean(msg.is_error),
+        subtype: msg.subtype,
+        durationMs: msg.duration_ms,
+        numTurns: msg.num_turns,
+        sessionId
       }
-    ];
+    });
+    return events;
   }
 
   if (type === "system") {
     const subtype = typeof msg.subtype === "string" ? msg.subtype.trim() : "";
+    if (subtype === "compact_boundary") {
+      return [
+        providerEvent,
+        {
+          type: "context_compacted",
+          payload: {
+            automatic: false,
+            phase: "system",
+            subtype,
+            sessionId,
+          },
+        },
+      ];
+    }
     const text =
       subtype === "hook_started"
         ? `Running ${typeof msg.hook_name === "string" && msg.hook_name.trim() ? msg.hook_name.trim() : "runtime hook"}`
@@ -251,7 +350,7 @@ export function mapSdkMessageToProviderEvents(raw: unknown): ProviderEvent[] {
           : subtype === "init"
             ? "Initializing Claude session"
             : subtype === "api_retry"
-              ? "Retrying provider request"
+              ? "Rebuilding Claude session after runtime change"
               : subtype
                 ? `System event: ${subtype}`
                 : "System event";

--- a/src/event-mapper/map-to-llm4zotero-event.ts
+++ b/src/event-mapper/map-to-llm4zotero-event.ts
@@ -102,6 +102,31 @@ export function mapToLlm4ZoteroEvent(event: AgentEvent): Llm4ZoteroAgentEvent | 
         text: asString(payload.text)
       };
     }
+    case "usage": {
+      return {
+        type: "usage",
+        inputTokens: asNumber(payload.inputTokens),
+        outputTokens: asNumber(payload.outputTokens),
+        cacheCreationInputTokens: asNumber(payload.cacheCreationInputTokens),
+        cacheReadInputTokens: asNumber(payload.cacheReadInputTokens),
+        contextTokens: asNumber(payload.contextTokens),
+        contextWindow: typeof payload.contextWindow === "number" && Number.isFinite(payload.contextWindow)
+          ? payload.contextWindow
+          : undefined,
+        contextWindowIsAuthoritative: payload.contextWindowIsAuthoritative === true,
+        percentage: typeof payload.percentage === "number" && Number.isFinite(payload.percentage)
+          ? payload.percentage
+          : undefined,
+        sessionId: asString(payload.sessionId) || undefined,
+        model: asString(payload.model) || undefined,
+      };
+    }
+    case "context_compacted": {
+      return {
+        type: "context_compacted",
+        automatic: payload.automatic === true,
+      };
+    }
     case "fallback": {
       const reason = asString(payload.reason) || "fallback";
       return {

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -627,23 +627,22 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       );
 
       if (resolvedFromCache) {
-        // Never forward generic aliases (sonnet/opus/haiku) directly to SDK.
-        // If resolution only bounces back the alias itself, treat as unresolved
-        // and let runtime defaults choose the effective model.
-        const normalizedResolved = resolvedFromCache.trim().toLowerCase();
-        const normalizedRequested = requestedModelRaw.trim().toLowerCase();
-        const isGenericAlias =
-          normalizedRequested === "sonnet" ||
-          normalizedRequested === "opus" ||
-          normalizedRequested === "haiku";
-        if (!(isGenericAlias && normalizedResolved === normalizedRequested)) {
-          // Use resolved model (from cache or env vars)
-          resolvedModel = resolvedFromCache;
+        // resolveModelAlias only returns the alias unchanged when the SDK's
+        // supportedModels() itself reports that alias as a valid value
+        // (e.g. Claude Code SDK reports "default"/"sonnet"/"haiku"). In that
+        // case the alias IS the SDK model identifier and must be forwarded —
+        // dropping it causes the SDK to fall back to its internal default.
+        resolvedModel = resolvedFromCache;
+      } else if (!cacheHit) {
+        // Cache miss: SDK hasn't been queried for available models yet.
+        // For the known Claude Code SDK aliases, forward the alias directly —
+        // the SDK accepts "opus"/"sonnet"/"haiku" as valid model values and
+        // this avoids falling back to the runtime default on the first request.
+        const rawLower = requestedModelRaw.trim().toLowerCase();
+        if (rawLower === "opus" || rawLower === "sonnet" || rawLower === "haiku") {
+          resolvedModel = rawLower;
         }
-      }
-
-      if (!cacheHit) {
-        // Cache miss: trigger async fetch to populate cache for next time
+        // Trigger async fetch to populate cache for subsequent requests
         this.fetchAndCacheModels(effectiveSettingSources).catch(() => {
           // Silently ignore, will retry on next request
         });

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -916,16 +916,21 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
         : "default");
     let resolvedModel: string | undefined;
     if (shouldForwardFrontendModel && requestedModelRaw && requestedModelRaw.toLowerCase() !== "default" && requestedModelRaw.toLowerCase() !== "auto") {
-      const liveModels = await this.listModels({ settingSources: effectiveSettingSources, providerKey });
-      const normalizedRequested = requestedModelRaw.trim().toLowerCase();
+      const modelInfos = await this.readSupportedModelsFromSdk({
+        settingSources: effectiveSettingSources,
+        providerKey,
+      });
       const normalizedResolved = resolveModelAlias(
         requestedModelRaw,
-        liveModels.map((value) => ({ value })),
+        modelInfos,
       )?.trim().toLowerCase();
-      const isGenericAlias =
-        normalizedRequested === "sonnet" || normalizedRequested === "opus" || normalizedRequested === "haiku";
-      if (normalizedResolved && !(isGenericAlias && normalizedResolved === normalizedRequested)) {
+      if (normalizedResolved) {
         resolvedModel = normalizedResolved;
+      } else {
+        const rawLower = requestedModelRaw.trim().toLowerCase();
+        if (rawLower === "opus" || rawLower === "sonnet" || rawLower === "haiku") {
+          resolvedModel = rawLower;
+        }
       }
     }
     const modelForSdk = resolvedModel;

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -2,12 +2,12 @@ import type { Query, PermissionMode, SDKUserMessage, SettingSource } from "@anth
 import { readFile } from "node:fs/promises";
 import { mkdirSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { ClaudeCodeRuntimeClient, ProviderEvent, RuntimeTurnRequest, RuntimeTurnStream } from "../runtime.js";
 import { mapSdkMessageToProviderEvents } from "../event-mapper/map-sdk-message.js";
 import { globalPermissionStore } from "../permissions/permission-store.js";
 import type { PermissionResult } from "../permissions/permission-store.js";
-import { resolveModelWithCache, setCachedModels } from "./model-resolver.js";
+import { resolveModelAlias } from "./model-resolver.js";
 import { createHotRuntimeTurn, HotRuntimePool, type HotRuntimeEntry } from "./hotRuntimePool.js";
 
 type QueryFunction = (args: {
@@ -51,7 +51,13 @@ type RuntimeRequestShape = {
   pinnedPaperContexts?: unknown;
   attachments?: unknown;
   screenshots?: unknown;
+  history?: unknown;
   activeNoteContext?: unknown;
+};
+
+type CompactTurnOptions = {
+  metadata: Record<string, unknown>;
+  autoCompactNeeded: boolean;
 };
 
 const RUNTIME_EFFORT_DESCENDING: RuntimeEffortLevel[] = ["max", "xhigh", "high", "medium", "low"];
@@ -220,6 +226,7 @@ function formatPaperPathLines(entries: RuntimePaperPathEntry[]): string[] {
 }
 function buildPromptText(userMessage: string, runtimeRequest: RuntimeRequestShape | undefined): string {
   const trimmedUserMessage = userMessage.trim();
+  if (/^\/compact(?:\s|$)/i.test(trimmedUserMessage)) return "/compact";
   if (trimmedUserMessage.startsWith("/")) return trimmedUserMessage;
   const lines: string[] = [trimmedUserMessage];
   if (!runtimeRequest) return lines.join("\n\n");
@@ -341,6 +348,44 @@ function toStableStringList(value: unknown, sort = false): string[] | null {
   if (sort) normalized.sort();
   return normalized;
 }
+function shouldAutoCompact(
+  metadata: Record<string, unknown>,
+  usageSnapshot: { contextTokens: number; contextWindow?: number } | undefined,
+): boolean {
+  if (metadata.claudeAutoCompactEligible !== true) return false;
+  const rawThreshold = Number(metadata.claudeAutoCompactThresholdPercent);
+  if (!Number.isFinite(rawThreshold)) return false;
+  const threshold = Math.max(0, Math.min(99, Math.round(rawThreshold)));
+  const estimatedContextTokens = Math.max(0, Number(metadata.claudeEstimatedContextTokens) || 0);
+  const contextTokens = Math.max(
+    estimatedContextTokens,
+    Math.max(0, Number(usageSnapshot?.contextTokens) || 0),
+  );
+  if (threshold === 0) return contextTokens > 0 || estimatedContextTokens > 0;
+  const contextWindow = Math.max(0, Number(usageSnapshot?.contextWindow) || 200_000);
+  if (contextTokens <= 0 || contextWindow <= 0) return false;
+  const percentage = Math.round((contextTokens / contextWindow) * 100);
+  return percentage >= threshold;
+}
+async function buildSettingsStackIdentity(
+  settingSources: SettingSource[],
+  resolveSettingsPathBySource: (source: "user" | "project" | "local", cwdOverride?: string) => string | undefined,
+  cwdOverride?: string,
+): Promise<string | null> {
+  const parts: string[] = [];
+  for (const source of settingSources) {
+    const path = resolveSettingsPathBySource(source, cwdOverride);
+    if (!path) continue;
+    try {
+      const raw = await readFile(path, "utf8");
+      parts.push(`${source}:${path}:${raw}`);
+    } catch {
+      parts.push(`${source}:${path}:missing`);
+    }
+  }
+  if (!parts.length) return null;
+  return createHash("sha256").update(parts.join("\n\n")).digest("hex");
+}
 function buildHotRuntimeSignature(
   queryOptions: Record<string, unknown>,
   metadata: Record<string, unknown>,
@@ -398,6 +443,29 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
   private readonly modelInfoTtlMs = 60_000;
   private readonly commandInfoTtlMs = 5 * 60_000;
   private readonly hotRuntimePool = new HotRuntimePool({ graceMs: 3000 });
+  private readonly usageSnapshots = new Map<string, { contextTokens: number; contextWindow?: number }>();
+
+  private mergeUsageSnapshot(
+    conversationKey: string,
+    next: { contextTokens?: number; contextWindow?: number },
+  ): { contextTokens: number; contextWindow?: number } {
+    const previous = this.usageSnapshots.get(conversationKey);
+    const contextTokens =
+      typeof next.contextTokens === "number" && Number.isFinite(next.contextTokens)
+        ? Math.max(0, next.contextTokens)
+        : previous?.contextTokens ?? 0;
+    const contextWindow =
+      typeof next.contextWindow === "number" && Number.isFinite(next.contextWindow) && next.contextWindow > 0
+        ? next.contextWindow
+        : previous?.contextWindow;
+    const merged = { contextTokens, contextWindow };
+    this.usageSnapshots.set(conversationKey, merged);
+    const liveEntry = this.hotRuntimePool.get(conversationKey);
+    if (liveEntry) {
+      liveEntry.lastUsageSnapshot = merged;
+    }
+    return merged;
+  }
 
   constructor(options: ClaudeAgentSdkRuntimeClientOptions = {}) {
     this.options = options;
@@ -414,21 +482,56 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
   }
 
   async startTurn(request: RuntimeTurnRequest): Promise<RuntimeTurnStream> {
+    const metadata = parseMetadata(request.metadata, this.options);
     const hotEntry = this.hotRuntimePool.get(request.conversationKey);
+    const autoCompactNeeded =
+      !/^\/compact(?:\s|$)/i.test(request.userMessage.trim()) &&
+      shouldAutoCompact(
+        metadata,
+        this.usageSnapshots.get(request.conversationKey) ?? hotEntry?.lastUsageSnapshot,
+      );
     if (hotEntry && hotEntry.mounts.size > 0) {
-      return this.startHotTurn(request, hotEntry);
+      return this.startHotTurn(request, hotEntry, { metadata, autoCompactNeeded });
     }
-    return this.startColdTurn(request);
+    return this.startColdTurn(request, { metadata, autoCompactNeeded });
   }
 
-  private async startHotTurn(request: RuntimeTurnRequest, entry: HotRuntimeEntry): Promise<RuntimeTurnStream> {
+  private async startHotTurn(
+    request: RuntimeTurnRequest,
+    entry: HotRuntimeEntry,
+    _options?: CompactTurnOptions,
+  ): Promise<RuntimeTurnStream> {
     const metadata = parseMetadata(request.metadata, this.options);
-    const queryOptions = await this.buildQueryOptions(request, metadata, entry.providerSessionId || request.providerSessionId);
-    const signature = buildHotRuntimeSignature(queryOptions, metadata);
-    if (!entry.query || entry.configSignature !== signature) {
-      if (entry.query || entry.configSignature) {
+    const settingSourcesOverride = parseSettingSourcesOverride(metadata);
+    const effectiveSettingSources = settingSourcesOverride ?? this.options.settingSources ?? ["user", "project"];
+    const effectiveCwd = this.resolveScopedCwd(request.metadata);
+    const providerIdentity = await buildSettingsStackIdentity(
+      effectiveSettingSources,
+      this.resolveSettingsPathBySource.bind(this),
+      effectiveCwd,
+    );
+    const shouldReuseProviderSession =
+      !providerIdentity || !entry.providerIdentity || entry.providerIdentity === providerIdentity;
+
+    let queryOptions = await this.buildQueryOptions(
+      request,
+      metadata,
+      shouldReuseProviderSession ? entry.providerSessionId || request.providerSessionId : undefined,
+    );
+    let signature = buildHotRuntimeSignature(queryOptions, metadata);
+    const shouldRestartForConfigChange =
+      Boolean(entry.query || entry.configSignature) && entry.configSignature !== signature;
+    const shouldForceFreshSession = !shouldReuseProviderSession || shouldRestartForConfigChange;
+
+    if (shouldForceFreshSession) {
+      queryOptions = await this.buildQueryOptions(request, metadata, undefined);
+      signature = buildHotRuntimeSignature(queryOptions, metadata);
+    }
+
+    if (!entry.query || entry.configSignature !== signature || shouldForceFreshSession) {
+      if (entry.query || entry.configSignature || entry.providerSessionId) {
         const preservedMounts = Array.from(entry.mounts);
-        const preservedSessionId = entry.providerSessionId;
+        const preservedSessionId = shouldForceFreshSession ? undefined : entry.providerSessionId;
         await this.closeHotRuntime(entry);
         this.hotRuntimePool.delete(request.conversationKey);
         entry = this.hotRuntimePool.ensure(request.conversationKey);
@@ -441,14 +544,18 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       const liveQuery = query({ prompt: entry.input, options: queryOptions });
       entry.query = liveQuery;
       entry.configSignature = signature;
+      entry.providerIdentity = providerIdentity || undefined;
       void this.consumeHotRuntime(entry, metadata, queryOptions);
     }
     const runId = randomUUID();
     const turn = createHotRuntimeTurn(runId);
     entry.currentTurn = turn;
+    const providerSessionId = entry.providerSessionId || request.providerSessionId;
+    turn.awaitingAutoCompact = /^\/compact(?:\s|$)/i.test(request.userMessage.trim());
+    turn.compactOnly = turn.awaitingAutoCompact;
     const message = await this.buildHotUserMessage({
       ...request,
-      providerSessionId: entry.providerSessionId || request.providerSessionId,
+      providerSessionId,
     });
     entry.pushMessage(message);
     return {
@@ -514,6 +621,42 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
                 },
               });
             }
+          }
+          if (event.type === "usage") {
+            const payload = event.payload as Record<string, unknown>;
+            const nextContextTokens = Number(payload.contextTokens);
+            const nextContextWindow = Number(payload.contextWindow);
+            const merged = this.mergeUsageSnapshot(entry.conversationKey, {
+              contextTokens: Number.isFinite(nextContextTokens) && nextContextTokens > 0
+                ? Math.max(0, nextContextTokens)
+                : undefined,
+              contextWindow:
+                Number.isFinite(nextContextWindow) && nextContextWindow > 0
+                  ? nextContextWindow
+                  : undefined,
+            });
+            entry.lastUsageSnapshot = merged;
+          }
+          if (currentTurn.awaitingAutoCompact) {
+            if (event.type === "context_compacted") {
+              currentTurn.queueEvent({
+                type: "context_compacted",
+                payload: { automatic: true },
+              });
+              continue;
+            }
+            if (event.type === "final") {
+              currentTurn.awaitingAutoCompact = false;
+              if (currentTurn.compactOnly) {
+                currentTurn.finish();
+                entry.currentTurn = null;
+                this.hotRuntimePool.scheduleCloseIfIdle(entry, (expired) => {
+                  void this.closeHotRuntime(expired);
+                });
+              }
+              continue;
+            }
+            continue;
           }
           if (event.type === "message_delta") {
             const payload = event.payload as Record<string, unknown>;
@@ -581,25 +724,38 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     };
   }
 
-  private async startColdTurn(request: RuntimeTurnRequest): Promise<RuntimeTurnStream> {
+  private async startColdTurn(
+    request: RuntimeTurnRequest,
+    options?: CompactTurnOptions,
+  ): Promise<RuntimeTurnStream> {
     const query = this.options.queryImpl ?? (await this.loadQuery());
-    const metadata = parseMetadata(request.metadata, this.options);
+    const metadata = options?.metadata ?? parseMetadata(request.metadata, this.options);
     const queryOptions = await this.buildQueryOptions(request, metadata, request.providerSessionId);
-    const prompt = await buildPromptInput(request, metadata);
+    const prompt: string | AsyncIterable<SDKUserMessage> = await buildPromptInput(request, metadata);
     const sdkStream = query({ prompt, options: queryOptions });
     return {
       runId: randomUUID(),
       providerSessionId: request.providerSessionId,
-      events: this.createColdProviderEventStream(sdkStream, request, metadata, queryOptions),
+      events: this.createColdProviderEventStream(
+        sdkStream,
+        request,
+        metadata,
+        queryOptions,
+        /^\/compact(?:\s|$)/i.test(request.userMessage.trim()),
+      ),
     };
   }
+
 
   private createColdProviderEventStream(
     sdkStream: Query,
     request: RuntimeTurnRequest,
     metadata: Record<string, unknown>,
     queryOptions: Record<string, unknown>,
+    awaitingAutoCompact = false,
   ): AsyncIterable<ProviderEvent> {
+    const usageSnapshots = this.usageSnapshots;
+    const hotRuntimePool = this.hotRuntimePool;
     const supportedEfforts = Array.isArray((queryOptions as Record<string, unknown>).supportedEfforts)
       ? ((queryOptions as Record<string, unknown>).supportedEfforts as string[])
       : ["default", "low", "medium", "high", "xhigh"];
@@ -632,12 +788,49 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       }
       for await (const raw of sdkStream) {
         const mapped = mapSdkMessageToProviderEvents(raw);
-        for (const event of mapped) yield event;
+        for (const event of mapped) {
+          if (event.type === "usage") {
+            const payload = event.payload as Record<string, unknown>;
+            const nextContextTokens = Number(payload.contextTokens);
+            const nextContextWindow = Number(payload.contextWindow);
+            const previous = usageSnapshots.get(request.conversationKey);
+            const merged = {
+              contextTokens:
+                Number.isFinite(nextContextTokens) && nextContextTokens > 0
+                  ? Math.max(0, nextContextTokens)
+                  : previous?.contextTokens ?? 0,
+              contextWindow:
+                Number.isFinite(nextContextWindow) && nextContextWindow > 0
+                  ? nextContextWindow
+                  : previous?.contextWindow,
+            };
+            usageSnapshots.set(request.conversationKey, merged);
+            const liveEntry = hotRuntimePool.get(request.conversationKey);
+            if (liveEntry) {
+              liveEntry.lastUsageSnapshot = merged;
+            }
+          }
+          if (awaitingAutoCompact) {
+            if (event.type === "context_compacted") {
+              yield {
+                type: "context_compacted",
+                payload: { automatic: true },
+              };
+              continue;
+            }
+            if (event.type === "final") {
+              awaitingAutoCompact = false;
+              continue;
+            }
+            continue;
+          }
+          yield event;
+        }
       }
     })();
   }
 
-  async listModels(options?: { settingSources?: Array<"user" | "project" | "local"> }): Promise<string[]> {
+  async listModels(options?: { settingSources?: Array<"user" | "project" | "local">; providerKey?: string }): Promise<string[]> {
     const sdkInfos = await this.readSupportedModelsFromSdk(options);
     const requestedSources = options?.settingSources;
     const settingSources = Array.isArray(requestedSources) && requestedSources.length > 0 ? requestedSources : this.options.settingSources ?? ["user", "project"];
@@ -655,15 +848,15 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     return Array.from(unique);
   }
 
-  async listCommands(options?: { settingSources?: Array<"user" | "project" | "local"> }): Promise<Array<{ name: string; description: string; argumentHint: string }>> {
+  async listCommands(options?: { settingSources?: Array<"user" | "project" | "local">; providerKey?: string }): Promise<Array<{ name: string; description: string; argumentHint: string }>> {
     const infos = await this.readSupportedCommandsFromSdk(options);
     return infos
       .map((entry) => ({ name: (entry.name || "").trim().replace(/^\/+/, ""), description: (entry.description || "").trim(), argumentHint: (entry.argumentHint || "").trim() }))
       .filter((entry) => entry.name.length > 0);
   }
 
-  async listEfforts(options?: { model?: string; settingSources?: Array<"user" | "project" | "local"> }): Promise<string[]> {
-    const sdkInfos = await this.readSupportedModelsFromSdk({ settingSources: options?.settingSources });
+  async listEfforts(options?: { model?: string; settingSources?: Array<"user" | "project" | "local">; providerKey?: string }): Promise<string[]> {
+    const sdkInfos = await this.readSupportedModelsFromSdk({ settingSources: options?.settingSources, providerKey: options?.providerKey });
     const model = (options?.model || "").trim().toLowerCase();
     const base = ["default", "low", "medium", "high"] as string[];
     if (model) {
@@ -712,23 +905,33 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     const customInstruction = parseCustomInstruction(metadata);
     const effectiveCwd = this.resolveScopedCwd(request.metadata);
     const effectiveSettingSources = settingSourcesOverride ?? this.options.settingSources ?? ["user", "project"];
+    const providerKey =
+      (await buildSettingsStackIdentity(
+        effectiveSettingSources,
+        this.resolveSettingsPathBySource.bind(this),
+        effectiveCwd,
+      )) ||
+      (typeof metadata.claudeConfigSource === "string" && metadata.claudeConfigSource.trim()
+        ? metadata.claudeConfigSource.trim()
+        : "default");
     let resolvedModel: string | undefined;
     if (shouldForwardFrontendModel && requestedModelRaw && requestedModelRaw.toLowerCase() !== "default" && requestedModelRaw.toLowerCase() !== "auto") {
-      const { model: resolvedFromCache, cacheHit } = resolveModelWithCache(requestedModelRaw, effectiveSettingSources);
-      if (resolvedFromCache) {
-        const normalizedResolved = resolvedFromCache.trim().toLowerCase();
-        const normalizedRequested = requestedModelRaw.trim().toLowerCase();
-        const isGenericAlias = normalizedRequested === "sonnet" || normalizedRequested === "opus" || normalizedRequested === "haiku";
-        if (!(isGenericAlias && normalizedResolved === normalizedRequested)) {
-          resolvedModel = resolvedFromCache;
-        }
-      }
-      if (!cacheHit) {
-        this.fetchAndCacheModels(effectiveSettingSources).catch(() => {});
+      const liveModels = await this.listModels({ settingSources: effectiveSettingSources, providerKey });
+      const normalizedRequested = requestedModelRaw.trim().toLowerCase();
+      const normalizedResolved = resolveModelAlias(
+        requestedModelRaw,
+        liveModels.map((value) => ({ value })),
+      )?.trim().toLowerCase();
+      const isGenericAlias =
+        normalizedRequested === "sonnet" || normalizedRequested === "opus" || normalizedRequested === "haiku";
+      if (normalizedResolved && !(isGenericAlias && normalizedResolved === normalizedRequested)) {
+        resolvedModel = normalizedResolved;
       }
     }
     const modelForSdk = resolvedModel;
-    const supportedEfforts = requestedEffort ? await this.listEfforts({ model: modelForSdk || requestedModel, settingSources: effectiveSettingSources }) : ["default", "low", "medium", "high", "xhigh"];
+    const supportedEfforts = requestedEffort
+      ? await this.listEfforts({ model: modelForSdk || requestedModel, settingSources: effectiveSettingSources, providerKey })
+      : ["default", "low", "medium", "high", "xhigh"];
     const supportedEffortSet = new Set(supportedEfforts.map((entry) => entry.trim().toLowerCase()).filter(Boolean));
     const resolvedEffort = (() => {
       if (!requestedEffort) return undefined;
@@ -859,10 +1062,10 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     return sdk.query;
   }
 
-  private async readSupportedModelsFromSdk(options?: { settingSources?: Array<"user" | "project" | "local"> }): Promise<ClaudeModelInfo[]> {
+  private async readSupportedModelsFromSdk(options?: { settingSources?: Array<"user" | "project" | "local">; providerKey?: string }): Promise<ClaudeModelInfo[]> {
     const requestedSources = options?.settingSources;
     const settingSources = Array.isArray(requestedSources) && requestedSources.length > 0 ? requestedSources : this.options.settingSources ?? ["user", "project"];
-    const cacheKey = settingSources.join(",");
+    const cacheKey = `${options?.providerKey || "default"}::${settingSources.join(",")}`;
     const cached = this.modelInfoCache.get(cacheKey);
     if (cached && Date.now() < cached.expiresAt) return cached.infos;
     try {
@@ -881,10 +1084,10 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     }
   }
 
-  private async readSupportedCommandsFromSdk(options?: { settingSources?: Array<"user" | "project" | "local"> }): Promise<ClaudeSlashCommandInfo[]> {
+  private async readSupportedCommandsFromSdk(options?: { settingSources?: Array<"user" | "project" | "local">; providerKey?: string }): Promise<ClaudeSlashCommandInfo[]> {
     const requestedSources = options?.settingSources;
     const settingSources = Array.isArray(requestedSources) && requestedSources.length > 0 ? requestedSources : this.options.settingSources ?? ["user", "project"];
-    const cacheKey = settingSources.join(",");
+    const cacheKey = `${options?.providerKey || "default"}::${settingSources.join(",")}`;
     const cached = this.commandInfoCache.get(cacheKey);
     if (cached && Date.now() < cached.expiresAt) return cached.commands;
     try {
@@ -900,15 +1103,6 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       return commands;
     } catch {
       return [];
-    }
-  }
-
-  private async fetchAndCacheModels(settingSources: string[]): Promise<void> {
-    try {
-      const models = await this.readSupportedModelsFromSdk({ settingSources: settingSources as Array<"user" | "project" | "local"> });
-      setCachedModels(settingSources, models.map((m) => ({ value: m.value, supportsEffort: m.supportsEffort, supportedEffortLevels: m.supportedEffortLevels })));
-    } catch {
-      // ignore
     }
   }
 
@@ -932,5 +1126,6 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     entry.query = null;
     entry.currentTurn = null;
     entry.configSignature = undefined;
+    entry.providerIdentity = undefined;
   }
 }

--- a/src/providers/hotRuntimePool.ts
+++ b/src/providers/hotRuntimePool.ts
@@ -10,6 +10,8 @@ export type HotRuntimeTurn = {
   runId: string;
   sessionId?: string;
   finalText: string;
+  awaitingAutoCompact: boolean;
+  compactOnly: boolean;
   queueEvent: (event: ProviderEvent) => void;
   finish: () => void;
   fail: (error: Error) => void;
@@ -28,6 +30,8 @@ export type HotRuntimeEntry = {
   closeInput: () => void;
   providerSessionId?: string;
   configSignature?: string;
+  providerIdentity?: string;
+  lastUsageSnapshot?: { contextTokens: number; contextWindow?: number };
   currentTurn: HotRuntimeTurn | null;
 };
 
@@ -110,6 +114,8 @@ export function createHotRuntimeTurn(runId: string): HotRuntimeTurn {
   return {
     runId,
     finalText: "",
+    awaitingAutoCompact: false,
+    compactOnly: false,
     queueEvent(event: ProviderEvent) {
       if (done || error) return;
       events.push(event);
@@ -161,6 +167,8 @@ export function createHotRuntimeEntry(conversationKey: string): HotRuntimeEntry 
     closeInput: channel.closeInput,
     providerSessionId: undefined,
     configSignature: undefined,
+    providerIdentity: undefined,
+    lastUsageSnapshot: undefined,
     currentTurn: null,
   };
 }

--- a/src/providers/model-resolver.ts
+++ b/src/providers/model-resolver.ts
@@ -21,12 +21,13 @@ const modelCache = new Map<
 
 const CACHE_TTL_MS = 60_000; // 1 minute cache
 
-function getCacheKey(settingSources: string[]): string {
-  return settingSources.join(",");
+function getCacheKey(settingSources: string[], providerKey = "default"): string {
+  return `${providerKey}::${settingSources.join(",")}`;
 }
 
 export function getCachedModels(
-  settingSources: string[]
+  settingSources: string[],
+  providerKey?: string,
 ): ModelInfo[] | undefined {
   const key = getCacheKey(settingSources);
   const cached = modelCache.get(key);
@@ -38,9 +39,10 @@ export function getCachedModels(
 
 export function setCachedModels(
   settingSources: string[],
-  models: ModelInfo[]
+  models: ModelInfo[],
+  providerKey?: string,
 ): void {
-  const key = getCacheKey(settingSources);
+  const key = getCacheKey(settingSources, providerKey);
   modelCache.set(key, {
     models,
     expiresAt: Date.now() + CACHE_TTL_MS,
@@ -152,7 +154,8 @@ function resolveModelFromEnv(alias: string): string | undefined {
  */
 export function resolveModelWithCache(
   alias: string,
-  settingSources: string[]
+  settingSources: string[],
+  providerKey?: string,
 ): { model: string | undefined; cacheHit: boolean } {
   const normalizedAlias = alias.toLowerCase().trim();
 
@@ -161,7 +164,7 @@ export function resolveModelWithCache(
     return { model: normalizedAlias, cacheHit: true };
   }
 
-  const cached = getCachedModels(settingSources);
+  const cached = getCachedModels(settingSources, providerKey);
   if (cached) {
     return { model: resolveModelAlias(alias, cached), cacheHit: true };
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11,6 +11,8 @@ export type ProviderEventType =
   | "confirmation_resolved"
   | "message_delta"
   | "message_rollback"
+  | "usage"
+  | "context_compacted"
   | "final"
   | "unknown";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export type AgentEventType =
   | "confirmation_resolved"
   | "message_delta"
   | "message_rollback"
+  | "usage"
+  | "context_compacted"
   | "final"
   | "fallback";
 

--- a/test/map-sdk-message.test.ts
+++ b/test/map-sdk-message.test.ts
@@ -50,7 +50,7 @@ describe("mapSdkMessageToProviderEvents", () => {
     expect(apiRetry).toContainEqual({
       type: "status",
       payload: expect.objectContaining({
-        text: "Retrying provider request",
+        text: "Rebuilding Claude session after runtime change",
       }),
     });
   });


### PR DESCRIPTION
## Summary

Three adapter-side fixes surfaced while getting the Zotero plugin working end-to-end on Windows:

### 1. Invalid path character in scope directories

`toSafePathSegment` allowed `:` and `@` as "safe" characters, but Zotero scope IDs use `libraryID:itemID` (e.g. `1:9344`), producing paths like `scopes/paper/1:9344/conversations/...`. Windows reserves `:` for drive letters, so `mkdir` fails with `ENOENT` and the turn falls back to the local runtime with *"Agent tools unavailable for this model"*.

Fix: drop `:` and `@` from the allowed set so they are replaced with `_`. Linux/macOS are unaffected — those characters were never required in the path, just permitted.

### 2. Zotero root not resolved on Windows

`start-bridge-server.ts` only consulted `$HOME`. Windows exposes the home directory via `$USERPROFILE`, so the Zotero root resolved to `undefined` and the `additional directories` / `runtime cwd` defaults were wrong.

Fix: fall back to `$USERPROFILE` when `$HOME` is unset, and add a `--zotero-root` CLI flag / `ZOTERO_ROOT` env var for users whose Zotero data lives outside the home directory (e.g. `D:\Zotero`).

### 3. UI model selection was silently overridden by runtime default

When the user picked sonnet/haiku in the UI, the bridge silently sent the request with no `model` option, causing the Claude Code SDK to fall back to its internal default (opus). Two paths were at fault in the adapter:

1. **Cache hit**: `resolveModelAlias` correctly bounced the alias back (`"sonnet" -> "sonnet"`) because the SDK's `supportedModels()` reports those aliases as valid values. The old guard in `claude-agent-sdk-runtime-client.ts` treated this as a failed resolution and dropped the model.
2. **Cache miss** (first request after startup): `resolveModelWithCache` returned undefined for the known aliases, again leaving the SDK to pick its own default.

Fix: trust `resolveModelAlias`'s output, and on cache miss forward `"opus"` / `"sonnet"` / `"haiku"` directly since the SDK accepts them as-is.

### Startup robustness + diagnostics (bonus)

- `readTextFile` no longer treats a missing optional file (e.g. `CLAUDE.md`) as fatal — the bridge now starts cleanly on fresh installs where the file hasn't been created yet.
- Opt-in `ADAPTER_LOG_FILE` env var / `--log-file` flag tees stdout/stderr to a file. Useful when the bridge is spawned without an attached terminal (via Zotero's `Subprocess` API), which would otherwise drop all diagnostic output. Default: off.

## Test plan

- [x] End-to-end verified on Windows 11: Zotero plugin in Claude Code Bridge mode → adapter → Claude CLI → response
- [x] Paper-scoped conversations now create `scopes/paper/1_9344/conversations/...` successfully
- [x] `--zotero-root D:/Zotero` correctly sets `runtime cwd` and `additional directories`
- [x] Selecting **haiku** in the UI now runs on `claude-haiku-4-5-20251001` for the full turn (confirmed via bridge log: `[MODEL] Frontend: haiku -> SDK: haiku` + all assistant events carry the haiku model ID)
- [x] Selecting **sonnet** similarly routes to `claude-sonnet-4-6`
- [x] Bridge starts without error when `CLAUDE.md` is absent
