### PR TITLE
Wire Zotero library-chat scope into Claude Code adapter

### DIFF
--- a/src/bridge/claude-code-runtime-adapter.ts
+++ b/src/bridge/claude-code-runtime-adapter.ts
@@ -216,6 +216,7 @@ export class ClaudeCodeRuntimeAdapter {
       providerSessionId,
       allowedTools: request.allowedTools,
       runtimeRequest: request.runtimeRequest,
+      mcpServers: request.mcpServers,
       metadata: request.metadata,
     });
     return {
@@ -330,6 +331,7 @@ export class ClaudeCodeRuntimeAdapter {
       providerSessionId,
       allowedTools: request.allowedTools,
       runtimeRequest: request.runtimeRequest,
+      mcpServers: request.mcpServers,
       metadata: request.metadata,
       signal,
     });

--- a/src/bridge/llm4zotero-agent-backend-adapter.ts
+++ b/src/bridge/llm4zotero-agent-backend-adapter.ts
@@ -412,6 +412,7 @@ export class Llm4ZoteroAgentBackendAdapter {
         providerSessionId: params.request.providerSessionId,
         allowedTools: params.request.allowedTools,
         runtimeRequest: params.request.runtimeRequest,
+        mcpServers: params.request.mcpServers,
         metadata: mergedMetadata,
         signal: params.signal
       },

--- a/src/bridge/llm4zotero-contract.ts
+++ b/src/bridge/llm4zotero-contract.ts
@@ -45,6 +45,8 @@ export type Llm4ZoteroAgentEvent =
   | { type: "fallback"; reason: string }
   | { type: "final"; text: string };
 
+export type Llm4ZoteroMcpServersConfig = Record<string, Record<string, unknown>>;
+
 export interface Llm4ZoteroRunTurnRequest {
   conversationKey: string | number;
   userText: string;
@@ -54,6 +56,7 @@ export interface Llm4ZoteroRunTurnRequest {
   scopeId?: string;
   scopeLabel?: string;
   runtimeRequest?: Record<string, unknown>;
+  mcpServers?: Llm4ZoteroMcpServersConfig;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -176,6 +176,8 @@ type RuntimeRequestShape = {
   paperContexts?: unknown;
   fullTextPaperContexts?: unknown;
   pinnedPaperContexts?: unknown;
+  selectedCollectionContexts?: unknown;
+  selectedTagContexts?: unknown;
   attachments?: unknown;
   screenshots?: unknown;
   history?: unknown;
@@ -201,6 +203,7 @@ const DEFAULT_BLOCKED_METADATA_KEYS = new Set<string>([
   "runtimeRequest",
   "runtimeCwdRelative",
   "model",
+  "mcpServers",
   "effort",
 ]);
 const IMAGE_MIME_BY_KIND: Record<string, "image/jpeg" | "image/png" | "image/gif" | "image/webp"> = {
@@ -232,6 +235,18 @@ function trimInline(value: unknown, max = 280): string {
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   return value as Record<string, unknown>;
+}
+function normalizeMcpServers(value: unknown): Record<string, Record<string, unknown>> | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const servers: Record<string, Record<string, unknown>> = {};
+  for (const [name, config] of Object.entries(record)) {
+    const normalizedName = name.trim();
+    const configRecord = asRecord(config);
+    if (!normalizedName || !configRecord) continue;
+    servers[normalizedName] = configRecord;
+  }
+  return Object.keys(servers).length > 0 ? servers : undefined;
 }
 function redactMcpConfig(value: unknown): Record<string, unknown> | undefined {
   const record = asRecord(value);
@@ -333,11 +348,29 @@ type RuntimePaperPathEntry = {
   contextFilePath?: string;
   mineruFullMdPath?: string;
 };
+type RuntimeCollectionScopeEntry = {
+  name: string;
+  collectionId?: number;
+  libraryID?: number;
+  path?: string;
+};
+type RuntimeTagScopeEntry = {
+  name: string;
+  libraryID?: number;
+  normalizedName?: string;
+  scope?: "allTagged" | "untagged";
+  includeAutomatic?: boolean;
+};
 function asPath(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
   if (!normalized || !normalized.startsWith("/")) return undefined;
   return normalized;
+}
+function asPositiveInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
 }
 function collectPaperPathEntries(entries: unknown, limit: number): RuntimePaperPathEntry[] {
   if (!Array.isArray(entries) || limit <= 0) return [];
@@ -358,6 +391,60 @@ function collectPaperPathEntries(entries: unknown, limit: number): RuntimePaperP
   }
   return collected;
 }
+function collectCollectionScopeEntries(entries: unknown, limit: number): RuntimeCollectionScopeEntry[] {
+  if (!Array.isArray(entries) || limit <= 0) return [];
+  const collected: RuntimeCollectionScopeEntry[] = [];
+  for (const raw of entries) {
+    if (collected.length >= limit) break;
+    const record = asRecord(raw);
+    if (!record) continue;
+    const collectionId = asPositiveInt(record.collectionId ?? record.id);
+    const libraryID = asPositiveInt(record.libraryID);
+    const name =
+      trimInline(record.name, 140) ||
+      (collectionId ? `Collection ${collectionId}` : "");
+    if (!name && !collectionId) continue;
+    const path = trimInline(record.path, 180);
+    collected.push({
+      name: name || "Selected collection",
+      collectionId,
+      libraryID,
+      path: path || undefined,
+    });
+  }
+  return collected;
+}
+function collectTagScopeEntries(entries: unknown, limit: number): RuntimeTagScopeEntry[] {
+  if (!Array.isArray(entries) || limit <= 0) return [];
+  const collected: RuntimeTagScopeEntry[] = [];
+  const seen = new Set<string>();
+  for (const raw of entries) {
+    if (collected.length >= limit) break;
+    const record = asRecord(raw);
+    if (!record) continue;
+    const scope =
+      record.scope === "allTagged" || record.scope === "untagged"
+        ? record.scope
+        : undefined;
+    const name =
+      trimInline(record.name, 140) ||
+      (scope === "allTagged" ? "All Tagged" : scope === "untagged" ? "Untagged" : "");
+    if (!name) continue;
+    const normalizedName = trimInline(record.normalizedName, 140) || undefined;
+    const libraryID = asPositiveInt(record.libraryID);
+    const key = `${libraryID || "any"}:${scope || "tag"}:${(normalizedName || name).toLowerCase()}:${record.includeAutomatic === true ? "auto" : "manual"}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    collected.push({
+      name,
+      libraryID,
+      normalizedName,
+      scope,
+      includeAutomatic: record.includeAutomatic === true || undefined,
+    });
+  }
+  return collected;
+}
 function formatPaperPathLines(entries: RuntimePaperPathEntry[]): string[] {
   return entries.map((entry) => {
     const pathHints = [
@@ -365,6 +452,27 @@ function formatPaperPathLines(entries: RuntimePaperPathEntry[]): string[] {
       typeof entry.contextItemId === "number" ? `contextItemId=${entry.contextItemId}` : "",
     ].filter(Boolean);
     return `- ${entry.title}${pathHints.length ? ` [${pathHints.join(" | ")}]` : ""}`;
+  });
+}
+function formatCollectionScopeLines(entries: RuntimeCollectionScopeEntry[]): string[] {
+  return entries.map((entry) => {
+    const hints = [
+      typeof entry.collectionId === "number" ? `collectionId=${entry.collectionId}` : "",
+      typeof entry.libraryID === "number" ? `libraryID=${entry.libraryID}` : "",
+      entry.path ? `path=${entry.path}` : "",
+    ].filter(Boolean);
+    return `- ${entry.name}${hints.length ? ` [${hints.join(" | ")}]` : ""}`;
+  });
+}
+function formatTagScopeLines(entries: RuntimeTagScopeEntry[]): string[] {
+  return entries.map((entry) => {
+    const hints = [
+      typeof entry.libraryID === "number" ? `libraryID=${entry.libraryID}` : "",
+      entry.normalizedName ? `normalizedName=${entry.normalizedName}` : "",
+      entry.scope ? `scope=${entry.scope}` : "",
+      entry.includeAutomatic ? "includeAutomatic=true" : "",
+    ].filter(Boolean);
+    return `- ${entry.name}${hints.length ? ` [${hints.join(" | ")}]` : ""}`;
   });
 }
 function formatFallbackHistory(runtimeRequest: RuntimeRequestShape | undefined): string[] {
@@ -406,6 +514,26 @@ function buildPromptText(
     : [];
   if (selectedTexts.length) {
     lines.push("Selected snippets:", ...selectedTexts.map((text, index) => `${index + 1}. ${text}`));
+  }
+  const selectedCollections = collectCollectionScopeEntries(runtimeRequest.selectedCollectionContexts, 8);
+  const selectedTags = collectTagScopeEntries(runtimeRequest.selectedTagContexts, 8);
+  if (selectedCollections.length) {
+    lines.push(
+      "Selected Zotero collection scope for this turn:",
+      ...formatCollectionScopeLines(selectedCollections),
+      selectedCollections.length === 1
+        ? "When the user says \"this folder\", \"this collection\", or asks what is inside it, treat that phrase as the selected collection above. Prefer scoped Zotero library_search or library_retrieve calls instead of asking which folder."
+        : "When the user refers to selected folders or collections, use the selected collection scopes above. Ask a clarification only if the requested collection is ambiguous among them.",
+    );
+  }
+  if (selectedTags.length) {
+    lines.push(
+      "Selected Zotero tag scope for this turn:",
+      ...formatTagScopeLines(selectedTags),
+      selectedTags.length === 1
+        ? "When the user says \"this tag\" or asks about tagged papers, treat that phrase as the selected tag above. Prefer scoped Zotero library_search or library_retrieve calls instead of asking which tag."
+        : "When the user refers to selected tags, use the selected tag scopes above. Ask a clarification only if the requested tag is ambiguous among them.",
+    );
   }
   const selectedPaperPathEntries = collectPaperPathEntries(runtimeRequest.selectedPaperContexts ?? runtimeRequest.paperContexts, 8);
   const fullTextPaperPathEntries = collectPaperPathEntries(runtimeRequest.fullTextPaperContexts, 6);
@@ -631,6 +759,7 @@ function buildHotRuntimeSignature(
       typeof queryOptions.appendSystemPrompt === "string" && queryOptions.appendSystemPrompt.trim()
         ? queryOptions.appendSystemPrompt
         : null,
+    mcpServers: normalizeMcpServers(queryOptions.mcpServers) ?? null,
     allowedTools: toStableStringList(queryOptions.allowedTools, true),
     configSourceMode:
       typeof metadata.claudeConfigSource === "string" && metadata.claudeConfigSource.trim()
@@ -1516,7 +1645,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
                     liveEntry.lastUsageSnapshot = merged;
                   }
                 }
-                if (event.type === "context_compacted" || event.type === "final") {
+                if (event.type === "context_compacted") {
                   const liveSnapshot = await getLiveContextUsageSnapshot(sdkStream);
                   if (liveSnapshot) {
                     const merged = mergeUsageSnapshot(request.conversationKey, liveSnapshot);
@@ -1779,6 +1908,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     const customInstruction = parseCustomInstruction(metadata);
     const effectiveCwd = this.resolveScopedCwd(request.metadata);
     const effectiveSettingSources = settingSourcesOverride ?? this.options.settingSources ?? ["user", "project", "local"];
+    const mcpServers = normalizeMcpServers(request.mcpServers ?? rawRequestMetadata.mcpServers);
     const providerKey =
       (await buildSettingsStackIdentity(
         effectiveSettingSources,
@@ -1879,6 +2009,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
         cwd: effectiveCwd,
         additionalDirectories: this.options.additionalDirectories,
         allowedTools: mergeAllowedTools(request.allowedTools, this.options.defaultAllowedTools),
+        mcpServers,
         settingSources: effectiveSettingSources,
         permissionMode: effectivePermissionMode,
         includePartialMessages: this.options.includePartialMessages,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from "./types.js";
+import type { JsonObject, McpServersConfig } from "./types.js";
 
 export type ProviderEventType =
   | "provider_event"
@@ -27,6 +27,7 @@ export interface RuntimeTurnRequest {
   providerSessionId?: string;
   allowedTools?: string[];
   runtimeRequest?: JsonObject;
+  mcpServers?: McpServersConfig;
   metadata?: JsonObject;
   signal?: AbortSignal;
 }

--- a/src/server/http-bridge.ts
+++ b/src/server/http-bridge.ts
@@ -80,6 +80,24 @@ function parseSettingSources(
   return accepted.length > 0 ? accepted : undefined;
 }
 
+function parseMcpServers(
+  value: unknown,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const servers: Record<string, Record<string, unknown>> = {};
+  for (const [name, config] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedName = name.trim();
+    if (
+      !normalizedName ||
+      !config ||
+      typeof config !== "object" ||
+      Array.isArray(config)
+    ) continue;
+    servers[normalizedName] = config as Record<string, unknown>;
+  }
+  return Object.keys(servers).length > 0 ? servers : undefined;
+}
+
 function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -145,6 +163,7 @@ function toRequestPayload(body: unknown): Llm4ZoteroRunTurnRequest {
       record.runtimeRequest && typeof record.runtimeRequest === "object"
         ? (record.runtimeRequest as Record<string, unknown>)
         : undefined,
+    mcpServers: parseMcpServers(record.mcpServers),
     metadata:
       record.metadata && typeof record.metadata === "object"
         ? (record.metadata as Record<string, unknown>)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export type AgentEventType =
   | "fallback";
 
 export type JsonObject = Record<string, unknown>;
+export type McpServerConfigValue = Record<string, unknown>;
+export type McpServersConfig = Record<string, McpServerConfigValue>;
 
 export interface AgentEvent<TPayload = JsonObject> {
   type: AgentEventType;
@@ -28,6 +30,7 @@ export interface RunTurnRequest {
   providerSessionId?: string;
   allowedTools?: string[];
   runtimeRequest?: JsonObject;
+  mcpServers?: McpServersConfig;
   metadata?: JsonObject;
   signal?: AbortSignal;
 }

--- a/tests/http-bridge.spec.ts
+++ b/tests/http-bridge.spec.ts
@@ -104,9 +104,21 @@ describe("http bridge server", () => {
 
   it("streams a single start line with the runtime runId", async () => {
     const seenResumes: Array<string | undefined> = [];
+    const seenMcpServers: Array<unknown> = [];
+    const seenAllowedTools: Array<unknown> = [];
+    const mcpServers = {
+      llm_for_zotero: {
+        type: "http",
+        url: "http://127.0.0.1:23119/llm-for-zotero/mcp",
+        headers: { Authorization: "Bearer token-1" },
+      },
+    };
+    const allowedTools = ["mcp__llm_for_zotero__library_search"];
     const runtimeClient: ClaudeCodeRuntimeClient = {
       async startTurn(request) {
         seenResumes.push(request.providerSessionId);
+        seenMcpServers.push(request.mcpServers);
+        seenAllowedTools.push(request.allowedTools);
         return {
           runId: "run-http-1",
           providerSessionId: request.providerSessionId,
@@ -133,12 +145,16 @@ describe("http bridge server", () => {
           conversationKey: "conv-1",
           userText: "hello",
           providerSessionId: "sess-http-resume",
+          allowedTools,
+          mcpServers,
         })
       });
 
       expect(response.ok).toBe(true);
       const lines = await readNdjsonLines(response);
       expect(seenResumes).toEqual(["sess-http-resume"]);
+      expect(seenMcpServers).toEqual([mcpServers]);
+      expect(seenAllowedTools).toEqual([allowedTools]);
       const starts = lines.filter((line) => line.type === "start");
       expect(starts).toEqual([{ type: "start", runId: "run-http-1" }]);
       expect(lines.at(-1)).toEqual({

--- a/tests/sdk-runtime-client.spec.ts
+++ b/tests/sdk-runtime-client.spec.ts
@@ -83,16 +83,26 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
       }
     });
 
+    const mcpServers = {
+      llm_for_zotero: {
+        type: "http",
+        url: "http://127.0.0.1:23119/llm-for-zotero/mcp",
+        headers: { Authorization: "Bearer token-1" },
+      },
+    };
+
     const stream = await runtime.startTurn({
       conversationKey: "conv-1",
       userMessage: "hello",
       providerSessionId: "session-old",
-      allowedTools: ["Read", "Bash"]
+      allowedTools: ["Read", "Bash"],
+      mcpServers,
     });
 
     expect(seenPrompt).toBe("hello");
     expect(seenOptions.resume).toBe("session-old");
     expect(seenOptions.allowedTools).toEqual(["Read", "Bash"]);
+    expect(seenOptions.mcpServers).toEqual(mcpServers);
 
     const types: string[] = [];
     for await (const event of stream.events) {
@@ -109,6 +119,92 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
       "provider_event",
       "final"
     ]);
+  });
+
+  it("renders selected Zotero collection and tag scopes in the Claude prompt", async () => {
+    let seenPrompt = "";
+
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl(args) {
+        seenPrompt = typeof args.prompt === "string" ? args.prompt : "";
+        return makeStream([
+          { type: "system", session_id: "session-scope", subtype: "init" },
+          {
+            type: "assistant",
+            session_id: "session-scope",
+            message: { content: [{ type: "text", text: "ok" }] },
+          },
+          { type: "result", session_id: "session-scope", result: "ok", is_error: false }
+        ]);
+      }
+    });
+
+    const stream = await runtime.startTurn({
+      conversationKey: "conv-scope",
+      userMessage: "can you find the commonality of the papers inside this folder?",
+      runtimeRequest: {
+        selectedCollectionContexts: [
+          {
+            collectionId: 42,
+            name: "Computational_Psychiatry",
+            libraryID: 1,
+          },
+        ],
+        selectedTagContexts: [
+          {
+            name: "Drift",
+            normalizedName: "drift",
+            libraryID: 1,
+          },
+        ],
+      },
+    });
+
+    for await (const _event of stream.events) {
+      // Drain the provider stream so the runtime reaches its final state.
+    }
+
+    expect(seenPrompt).toContain("Selected Zotero collection scope for this turn:");
+    expect(seenPrompt).toContain("Computational_Psychiatry");
+    expect(seenPrompt).toContain("collectionId=42");
+    expect(seenPrompt).toContain("libraryID=1");
+    expect(seenPrompt).toContain("\"this folder\"");
+    expect(seenPrompt).toContain("library_search");
+    expect(seenPrompt).toContain("library_retrieve");
+    expect(seenPrompt).toContain("Selected Zotero tag scope for this turn:");
+    expect(seenPrompt).toContain("Drift");
+    expect(seenPrompt).toContain("normalizedName=drift");
+  });
+
+  it("does not request live context usage after normal final results", async () => {
+    let contextUsageCalls = 0;
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl() {
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "system", session_id: "session-final", subtype: "init" };
+            yield { type: "result", session_id: "session-final", result: "done", is_error: false };
+          },
+          async getContextUsage() {
+            contextUsageCalls += 1;
+            throw new Error("getContextUsage should not be called after final");
+          },
+          close() {},
+        } as any;
+      },
+    });
+
+    const stream = await runtime.startTurn({
+      conversationKey: "conv-final-context",
+      userMessage: "hello",
+    });
+    const types: string[] = [];
+    for await (const event of stream.events) {
+      types.push(event.type);
+    }
+
+    expect(types).toContain("final");
+    expect(contextUsageCalls).toBe(0);
   });
 
   it("emits SDK canUseTool permission requests on cold streams before resolution", async () => {
@@ -658,6 +754,71 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
 
     expect(queryCount).toBe(2);
     expect(seenResumes).toEqual([undefined, "sess-hot-rebuild"]);
+  });
+
+  it("rebuilds retained hot runtime when MCP server config changes", async () => {
+    let queryCount = 0;
+    const seenResumes: Array<unknown> = [];
+    const seenMcpServers: Array<unknown> = [];
+    let turnIndex = 0;
+    const makeMcpServers = (token: string) => ({
+      llm_for_zotero: {
+        type: "http",
+        url: "http://127.0.0.1:23119/llm-for-zotero/mcp",
+        headers: {
+          Authorization: "Bearer static-token",
+          "X-LLM-For-Zotero-Scope": token,
+        },
+      },
+    });
+
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl(args) {
+        const options = args.options as Record<string, unknown>;
+        const prompt = args.prompt;
+        if (typeof prompt !== "string") {
+          queryCount += 1;
+          seenResumes.push(options.resume);
+          seenMcpServers.push(options.mcpServers);
+        }
+        return {
+          async *[Symbol.asyncIterator]() {
+            for await (const _message of prompt as AsyncIterable<unknown>) {
+              turnIndex += 1;
+              yield { type: "system", session_id: "sess-hot-mcp", subtype: "init" };
+              yield { type: "result", session_id: "sess-hot-mcp", result: `ok-${turnIndex}`, is_error: false };
+            }
+          },
+          close() {},
+        } as any;
+      }
+    });
+
+    await runtime.retainHotRuntime({ conversationKey: "conv-hot-mcp", userMessage: "" }, "mount-1");
+    const first = await runtime.startTurn({
+      conversationKey: "conv-hot-mcp",
+      userMessage: "hello",
+      mcpServers: makeMcpServers("scope-token-1"),
+    });
+    for await (const _event of first.events) {
+      void _event;
+    }
+
+    const second = await runtime.startTurn({
+      conversationKey: "conv-hot-mcp",
+      userMessage: "again",
+      mcpServers: makeMcpServers("scope-token-2"),
+    });
+    for await (const _event of second.events) {
+      void _event;
+    }
+
+    expect(queryCount).toBe(2);
+    expect(seenResumes).toEqual([undefined, "sess-hot-mcp"]);
+    expect(seenMcpServers).toEqual([
+      makeMcpServers("scope-token-1"),
+      makeMcpServers("scope-token-2"),
+    ]);
   });
 
   it("retries retained hot runtime with high when unknown xhigh effort fails before init", async () => {


### PR DESCRIPTION
## Description
This PR lets Claude Code receive the library-chat context that LLM-for-Zotero sends for scoped Zotero turns.
## Summary
Forwards mcpServers through the HTTP bridge, adapter contract, runtime request, and Claude Agent SDK options.
Adds selected Zotero collection/tag scope rendering to the Claude prompt, including collectionId, libraryID, tag metadata, and explicit guidance for resolving “this folder”, “this collection”, and “this tag”.
Includes mcpServers in the hot-runtime signature so retained Claude SDK runtimes rebuild when scoped MCP config changes.
Redacts MCP server config from ordinary metadata handling.
Avoids querying live context usage after normal final results.
## Why
Claude Code mode could receive paper snippets, but library-chat scope was incomplete at the adapter boundary. In practice, a prompt like “find the commonality of papers inside this folder” could still make Claude ask which folder, even though LLM-for-Zotero had already selected a collection.
This PR makes the selected collection/tag scope and scoped Zotero MCP tools visible to the Claude SDK runtime, so Claude Code can use library_search, library_retrieve, and related Zotero tools against the intended library-chat context.
## Tests
Adds HTTP bridge coverage for forwarding mcpServers and allowedTools.
Adds SDK runtime coverage for selected collection/tag prompt rendering.
Adds SDK runtime coverage for hot-runtime rebuild when MCP scope config changes.
Adds coverage that normal final results do not request live context usage.


## How to Test

This PR should be tested together with the matching `llm-for-zotero` Claude Code changes in PR `258`.

### 1. Run the adapter branch

In `cc-llm4zotero-adapter`:

```bash
git fetch origin
git checkout feat/library_chat
npm install
npm run build
npm test
```

Start the bridge from this PR branch:

```bash
npm run serve:bridge
```

Verify it is listening:

```bash
curl -fsS http://127.0.0.1:19787/healthz
```

If an older daemon is already running, stop or restart it so Zotero does not hit stale adapter code:

```bash
npm run daemon:stop
npm run daemon:start
# or
npm run daemon:restart
```

For simplest PR testing, prefer the foreground `npm run serve:bridge` command so logs are visible.

### 2. Run the matching llm-for-zotero branch

In `llm-for-zotero`:

```bash
git fetch origin
gh pr checkout 258
npm install
npm run typecheck
```

Recommended targeted checks:

```bash
npx tsx node_modules/mocha/bin/mocha.js --require ./test/register.cjs test/codexZoteroMcpServer.test.ts
npx tsx node_modules/mocha/bin/mocha.js --require ./test/register.cjs test/externalBackendBridge.approvalRequired.test.ts
npx tsx node_modules/mocha/bin/mocha.js --require ./test/register.cjs test/codexAppServerNativeClient.test.ts
```

Optional workflow smoke:

```bash
npm run test:workflow
```

Then run the plugin in Zotero:

```bash
npm start
```

### 3. Configure Zotero

In Zotero preferences, open `llm-for-zotero` -> `Agent`.

Set:

- `Enable Claude Code integration`: on
- `Bridge URL`: `http://127.0.0.1:19787`
- `Zotero MCP tools`: enabled for Claude Code/native turns
- `Claude Config Source`: default
- `Permission Mode`: safe

Make sure Claude Code CLI is installed and authenticated before testing.

### 4. Manual integration test

In Zotero:

1. Open `Library chat`.
2. Add/select a Zotero collection as context, for example `Computational_Psychiatry`.
3. Switch the chat to `Claude Code`.
4. Ask:

```text
can you find the commonality of the papers inside this folder?
```

Expected behavior:

- Claude Code should recognize the selected collection.
- It should not ask “which folder?” when only one collection scope is selected.
- The prompt/tool flow should preserve the collection name and IDs.
- Claude Code should use scoped Zotero MCP tools such as `library_search` / `library_retrieve`.
- The answer should analyze papers from the selected collection, not the whole library.

Also test tag scope:

1. Select a Zotero tag as context.
2. Ask:

```text
what are the main themes in this tag?
```

Expected behavior:

- Claude Code should resolve “this tag” to the selected tag.
- It should use scoped Zotero MCP tools rather than asking which tag.

For paper context regression:

1. Open/select an individual paper.
2. Switch to Claude Code.
3. Ask for an overview or close reading.

Expected behavior:

- `paper_read` should receive the active/selected paper context.
- If MinerU metadata is available from the plugin side, `paper_read` should still be able to prefer the native MinerU path.



<img width="1016" height="934" alt="image" src="https://github.com/user-attachments/assets/5a287b7b-c307-480d-b87a-f9ba3ab66816" />
