### PR TITLE
Add PDF reading support to Claude Code mode

### DIFF
--- a/src/bridge/claude-code-runtime-adapter.ts
+++ b/src/bridge/claude-code-runtime-adapter.ts
@@ -3,7 +3,11 @@ import type { SessionMapper } from "../session-link/session-mapper.js";
 import type { TraceStore } from "../trace-store/trace-store.js";
 import type { AgentEvent, RunTurnHooks, RunTurnOutcome, RunTurnRequest } from "../types.js";
 import { mapProviderEvent } from "../event-mapper/map-provider-event.js";
-import { collectLocalPdfs, sanitizeLocalPdfOutput } from "../local-pdf.js";
+import {
+  collectLocalPdfs,
+  LocalPdfOutputStreamSanitizer,
+  sanitizeLocalPdfOutput,
+} from "../local-pdf.js";
 
 export interface ClaudeCodeRuntimeAdapterOptions {
   runtimeClient: ClaudeCodeRuntimeClient;
@@ -292,7 +296,7 @@ export class ClaudeCodeRuntimeAdapter {
       });
     }
     const providerSessionId = initialSessionId;
-    const effectiveRequest = hasHistoryGap
+    const effectiveRequest = isLocalPdfTurn || hasHistoryGap
       ? this.withResumeFallbackHistory(request)
       : request;
 
@@ -358,6 +362,7 @@ export class ClaudeCodeRuntimeAdapter {
     const sessionMapKey = this.buildSessionMapKey(request);
     const localPdfs = collectLocalPdfs(request.runtimeRequest);
     const persistProviderSession = localPdfs.length === 0;
+    const outputStreamSanitizer = new LocalPdfOutputStreamSanitizer(localPdfs);
     const stream = await this.runtimeClient.startTurn({
       conversationKey: request.conversationKey,
       userMessage: request.userMessage,
@@ -387,9 +392,11 @@ export class ClaudeCodeRuntimeAdapter {
     let pendingTextDelta = "";
     let lastTextDeltaTs: number | undefined;
 
-    const flushPendingTextDelta = async (): Promise<void> => {
-      if (!pendingTextDelta) return;
-      const redactedDelta = sanitizeLocalPdfOutput(pendingTextDelta, localPdfs);
+    const emitTextDelta = async (
+      redactedDelta: string,
+      eventTs: number | undefined,
+    ): Promise<void> => {
+      if (!redactedDelta) return;
       const mergedEvent: AgentEvent = {
         type: "message_delta",
         ts: Date.now(),
@@ -401,18 +408,46 @@ export class ClaudeCodeRuntimeAdapter {
         conversationKey: request.conversationKey,
         runId: stream.runId,
         textLength: redactedDelta.length,
-        eventTs: lastTextDeltaTs,
+        eventTs,
       });
+      await this.emitEvent(stream.runId, request.conversationKey, mergedEvent, hooks);
+    };
+
+    const flushPendingTextDelta = async (): Promise<void> => {
+      if (!pendingTextDelta) return;
+      const redactedDelta = outputStreamSanitizer.pushText(
+        "message_delta",
+        pendingTextDelta,
+      );
+      const eventTs = lastTextDeltaTs;
       pendingTextDelta = "";
       lastTextDeltaTs = undefined;
-      await this.emitEvent(stream.runId, request.conversationKey, mergedEvent, hooks);
+      await emitTextDelta(redactedDelta, eventTs);
+    };
+
+    const flushHeldTextDelta = async (): Promise<void> => {
+      await emitTextDelta(
+        outputStreamSanitizer.flushText("message_delta"),
+        lastTextDeltaTs,
+      );
     };
 
     try {
       for await (const providerEvent of stream.events) {
         const mappedEvent = mapProviderEvent(providerEvent);
+        const mappedProviderType =
+          mappedEvent.type === "provider_event" &&
+          mappedEvent.payload &&
+          typeof mappedEvent.payload === "object"
+            ? (mappedEvent.payload as Record<string, unknown>).providerType
+            : undefined;
         const event = mappedEvent.type === "message_delta"
           ? mappedEvent
+          : mappedProviderType === "stream_event"
+            ? outputStreamSanitizer.sanitizeChunk(
+                "provider_event:stream_event",
+                mappedEvent,
+              )
           : sanitizeLocalPdfOutput(mappedEvent, localPdfs);
         const eventSessionId = this.extractSessionId(event.payload);
         const providerType =
@@ -448,6 +483,9 @@ export class ClaudeCodeRuntimeAdapter {
 
         await flushPendingTextDelta();
         if (event.type === "final") {
+          await flushHeldTextDelta();
+        }
+        if (event.type === "final") {
           const output = event.payload.output;
           this.logStreamingTiming("emit_final", {
             conversationKey: request.conversationKey,
@@ -467,6 +505,8 @@ export class ClaudeCodeRuntimeAdapter {
       }
 
       await flushPendingTextDelta();
+      await flushHeldTextDelta();
+      outputStreamSanitizer.discardAll();
       this.logStreamingTiming("return_outcome", {
         conversationKey: request.conversationKey,
         runId: stream.runId,
@@ -481,6 +521,7 @@ export class ClaudeCodeRuntimeAdapter {
         finalText: sanitizeLocalPdfOutput(finalText, localPdfs),
       };
     } catch (error) {
+      outputStreamSanitizer.discardAll();
       const originalMessage = error instanceof Error ? error.message : String(error);
       const err = new Error(sanitizeLocalPdfOutput(originalMessage, localPdfs));
       const fallbackEvent: AgentEvent = {

--- a/src/bridge/claude-code-runtime-adapter.ts
+++ b/src/bridge/claude-code-runtime-adapter.ts
@@ -3,6 +3,7 @@ import type { SessionMapper } from "../session-link/session-mapper.js";
 import type { TraceStore } from "../trace-store/trace-store.js";
 import type { AgentEvent, RunTurnHooks, RunTurnOutcome, RunTurnRequest } from "../types.js";
 import { mapProviderEvent } from "../event-mapper/map-provider-event.js";
+import { collectLocalPdfs, sanitizeLocalPdfOutput } from "../local-pdf.js";
 
 export interface ClaudeCodeRuntimeAdapterOptions {
   runtimeClient: ClaudeCodeRuntimeClient;
@@ -10,7 +11,7 @@ export interface ClaudeCodeRuntimeAdapterOptions {
   traceStore?: TraceStore;
 }
 
-type ResumeSource = "map" | "legacy_provider_map" | "request_hint" | "none" | "force_fresh";
+type ResumeSource = "map" | "legacy_provider_map" | "request_hint" | "none" | "force_fresh" | "history_gap" | "local_pdf";
 
 export class ClaudeCodeRuntimeAdapter {
   private readonly runtimeClient: ClaudeCodeRuntimeClient;
@@ -121,6 +122,10 @@ export class ClaudeCodeRuntimeAdapter {
     return requestOrConversationKey.conversationKey;
   }
 
+  private buildLocalPdfHistoryGapKey(conversationKey: string): string {
+    return `${conversationKey}::local-pdf-history-gap`;
+  }
+
   private buildLegacyProviderSessionMapKey(
     requestOrConversationKey:
       | RunTurnRequest
@@ -201,6 +206,7 @@ export class ClaudeCodeRuntimeAdapter {
         : requestOrConversationKey.conversationKey;
     await this.sessionMapper.delete(baseConversationKey);
     await this.sessionMapper.deleteByPrefix(`${baseConversationKey}::provider:`);
+    await this.sessionMapper.delete(this.buildLocalPdfHistoryGapKey(baseConversationKey));
     await this.runtimeClient.invalidateHotRuntime?.(baseConversationKey);
   }
 
@@ -209,16 +215,18 @@ export class ClaudeCodeRuntimeAdapter {
     const metadata = request.metadata && typeof request.metadata === "object"
       ? (request.metadata as Record<string, unknown>)
       : {};
-    const { providerSessionId } = await this.resolveProviderSessionId(request);
-    await this.runtimeClient.warmHotRuntime?.({
-      conversationKey: request.conversationKey,
-      userMessage: "",
-      providerSessionId,
-      allowedTools: request.allowedTools,
-      runtimeRequest: request.runtimeRequest,
-      mcpServers: request.mcpServers,
-      metadata: request.metadata,
-    });
+    if (collectLocalPdfs(request.runtimeRequest).length === 0) {
+      const { providerSessionId } = await this.resolveProviderSessionId(request);
+      await this.runtimeClient.warmHotRuntime?.({
+        conversationKey: request.conversationKey,
+        userMessage: "",
+        providerSessionId,
+        allowedTools: request.allowedTools,
+        runtimeRequest: request.runtimeRequest,
+        mcpServers: request.mcpServers,
+        metadata: request.metadata,
+      });
+    }
     return {
       conversationKey: request.conversationKey,
       mountId,
@@ -237,6 +245,8 @@ export class ClaudeCodeRuntimeAdapter {
 
   async runTurn(request: RunTurnRequest, hooks: RunTurnHooks = {}): Promise<RunTurnOutcome> {
     const signal = hooks.signal ?? request.signal;
+    const localPdfs = collectLocalPdfs(request.runtimeRequest);
+    const isLocalPdfTurn = localPdfs.length > 0;
     if (hooks.onEvent) {
       await hooks.onEvent({
         type: "provider_event",
@@ -253,12 +263,20 @@ export class ClaudeCodeRuntimeAdapter {
         (request.metadata as Record<string, unknown>).forceFreshSession === true,
     );
     const sessionMapKey = this.buildSessionMapKey(request);
+    const historyGapKey = this.buildLocalPdfHistoryGapKey(request.conversationKey);
     if (forceFreshSession) {
       await this.invalidateConversationSession(request);
     }
+    const hasHistoryGap = !forceFreshSession && !isLocalPdfTurn && Boolean(
+      await this.sessionMapper.get(historyGapKey),
+    );
     const resolvedResume = forceFreshSession
       ? { providerSessionId: undefined, source: "force_fresh" as ResumeSource }
-      : await this.resolveProviderSessionId(request);
+      : isLocalPdfTurn
+        ? { providerSessionId: undefined, source: "local_pdf" as ResumeSource }
+        : hasHistoryGap
+          ? { providerSessionId: undefined, source: "history_gap" as ResumeSource }
+          : await this.resolveProviderSessionId(request);
     const initialSessionId = resolvedResume.providerSessionId;
     if (hooks.onEvent) {
       await hooks.onEvent({
@@ -273,13 +291,17 @@ export class ClaudeCodeRuntimeAdapter {
         },
       });
     }
-    let providerSessionId = initialSessionId;
+    const providerSessionId = initialSessionId;
+    const effectiveRequest = hasHistoryGap
+      ? this.withResumeFallbackHistory(request)
+      : request;
 
     let firstOutcome: RunTurnOutcome;
     try {
-      firstOutcome = await this.runTurnOnce(request, hooks, signal, providerSessionId);
+      firstOutcome = await this.runTurnOnce(effectiveRequest, hooks, signal, providerSessionId);
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
+      const originalMessage = error instanceof Error ? error.message : String(error);
+      const err = new Error(sanitizeLocalPdfOutput(originalMessage, localPdfs));
       if (providerSessionId && this.isInvalidThinkingSignatureError(err.message)) {
         await this.sessionMapper.delete(sessionMapKey);
         hooks.onEvent?.({
@@ -304,6 +326,15 @@ export class ClaudeCodeRuntimeAdapter {
       });
       firstOutcome = await this.runTurnOnce(this.withResumeFallbackHistory(request), hooks, signal, undefined);
     }
+    if (isLocalPdfTurn && firstOutcome.status === "completed") {
+      await this.sessionMapper.delete(sessionMapKey);
+      await this.sessionMapper.deleteByPrefix(`${sessionMapKey}::provider:`);
+      await this.sessionMapper.set(historyGapKey, "1");
+      return { ...firstOutcome, providerSessionId: undefined };
+    }
+    if (hasHistoryGap && firstOutcome.status === "completed" && firstOutcome.providerSessionId) {
+      await this.sessionMapper.delete(historyGapKey);
+    }
     return firstOutcome;
   }
 
@@ -325,6 +356,8 @@ export class ClaudeCodeRuntimeAdapter {
     providerSessionId: string | undefined,
   ): Promise<RunTurnOutcome> {
     const sessionMapKey = this.buildSessionMapKey(request);
+    const localPdfs = collectLocalPdfs(request.runtimeRequest);
+    const persistProviderSession = localPdfs.length === 0;
     const stream = await this.runtimeClient.startTurn({
       conversationKey: request.conversationKey,
       userMessage: request.userMessage,
@@ -337,7 +370,7 @@ export class ClaudeCodeRuntimeAdapter {
     });
 
     let resolvedSessionId = providerSessionId;
-    if (stream.providerSessionId) {
+    if (persistProviderSession && stream.providerSessionId) {
       resolvedSessionId = stream.providerSessionId;
       await this.sessionMapper.set(sessionMapKey, stream.providerSessionId);
     }
@@ -345,7 +378,9 @@ export class ClaudeCodeRuntimeAdapter {
     hooks.onStart?.({
       runId: stream.runId,
       conversationKey: request.conversationKey,
-      providerSessionId: stream.providerSessionId ?? providerSessionId,
+      providerSessionId: persistProviderSession
+        ? stream.providerSessionId ?? providerSessionId
+        : undefined,
     });
 
     let finalText = "";
@@ -354,17 +389,18 @@ export class ClaudeCodeRuntimeAdapter {
 
     const flushPendingTextDelta = async (): Promise<void> => {
       if (!pendingTextDelta) return;
+      const redactedDelta = sanitizeLocalPdfOutput(pendingTextDelta, localPdfs);
       const mergedEvent: AgentEvent = {
         type: "message_delta",
         ts: Date.now(),
         payload: {
-          delta: pendingTextDelta,
+          delta: redactedDelta,
         },
       };
       this.logStreamingTiming("emit_merged_message_delta", {
         conversationKey: request.conversationKey,
         runId: stream.runId,
-        textLength: pendingTextDelta.length,
+        textLength: redactedDelta.length,
         eventTs: lastTextDeltaTs,
       });
       pendingTextDelta = "";
@@ -374,7 +410,10 @@ export class ClaudeCodeRuntimeAdapter {
 
     try {
       for await (const providerEvent of stream.events) {
-        const event = mapProviderEvent(providerEvent);
+        const mappedEvent = mapProviderEvent(providerEvent);
+        const event = mappedEvent.type === "message_delta"
+          ? mappedEvent
+          : sanitizeLocalPdfOutput(mappedEvent, localPdfs);
         const eventSessionId = this.extractSessionId(event.payload);
         const providerType =
           event.type === "provider_event" && event.payload && typeof event.payload === "object"
@@ -388,7 +427,12 @@ export class ClaudeCodeRuntimeAdapter {
           event.type === "tool_result" ||
           event.type === "message_delta" ||
           event.type === "final";
-        if (canAdoptSessionId && eventSessionId && eventSessionId !== resolvedSessionId) {
+        if (
+          persistProviderSession &&
+          canAdoptSessionId &&
+          eventSessionId &&
+          eventSessionId !== resolvedSessionId
+        ) {
           resolvedSessionId = eventSessionId;
           await this.sessionMapper.set(sessionMapKey, eventSessionId);
         }
@@ -432,12 +476,13 @@ export class ClaudeCodeRuntimeAdapter {
       return {
         runId: stream.runId,
         conversationKey: request.conversationKey,
-        providerSessionId: resolvedSessionId,
+        providerSessionId: persistProviderSession ? resolvedSessionId : undefined,
         status: signal?.aborted ? "cancelled" : "completed",
-        finalText,
+        finalText: sanitizeLocalPdfOutput(finalText, localPdfs),
       };
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
+      const originalMessage = error instanceof Error ? error.message : String(error);
+      const err = new Error(sanitizeLocalPdfOutput(originalMessage, localPdfs));
       const fallbackEvent: AgentEvent = {
         type: "fallback",
         ts: Date.now(),
@@ -451,9 +496,9 @@ export class ClaudeCodeRuntimeAdapter {
       return {
         runId: stream.runId,
         conversationKey: request.conversationKey,
-        providerSessionId: resolvedSessionId,
+        providerSessionId: persistProviderSession ? resolvedSessionId : undefined,
         status: signal?.aborted ? "cancelled" : "failed",
-        finalText,
+        finalText: sanitizeLocalPdfOutput(finalText, localPdfs),
         error: err.message,
       };
     }

--- a/src/bridge/claude-code-runtime-adapter.ts
+++ b/src/bridge/claude-code-runtime-adapter.ts
@@ -391,6 +391,31 @@ export class ClaudeCodeRuntimeAdapter {
     let finalText = "";
     let pendingTextDelta = "";
     let lastTextDeltaTs: number | undefined;
+    let lastReasoningRound = 1;
+    let lastReasoningTs: number | undefined;
+
+    const sanitizeReasoningEvent = (event: AgentEvent): AgentEvent => {
+      const sanitized = sanitizeLocalPdfOutput(event, localPdfs);
+      if (event.type !== "reasoning") return sanitized;
+      const payload = event.payload && typeof event.payload === "object"
+        ? (event.payload as Record<string, unknown>)
+        : {};
+      const sanitizedPayload = sanitized.payload && typeof sanitized.payload === "object"
+        ? (sanitized.payload as Record<string, unknown>)
+        : {};
+      if (typeof payload.details !== "string") return sanitized;
+      if (typeof payload.round === "number" && Number.isFinite(payload.round)) {
+        lastReasoningRound = payload.round;
+      }
+      lastReasoningTs = event.ts;
+      return {
+        ...sanitized,
+        payload: {
+          ...sanitizedPayload,
+          details: outputStreamSanitizer.pushText("reasoning", payload.details),
+        },
+      };
+    };
 
     const emitTextDelta = async (
       redactedDelta: string,
@@ -432,6 +457,19 @@ export class ClaudeCodeRuntimeAdapter {
       );
     };
 
+    const flushHeldReasoning = async (): Promise<void> => {
+      const details = outputStreamSanitizer.flushText("reasoning");
+      if (!details) return;
+      await this.emitEvent(stream.runId, request.conversationKey, {
+        type: "reasoning",
+        ts: lastReasoningTs ?? Date.now(),
+        payload: {
+          round: lastReasoningRound,
+          details,
+        },
+      }, hooks);
+    };
+
     try {
       for await (const providerEvent of stream.events) {
         const mappedEvent = mapProviderEvent(providerEvent);
@@ -443,6 +481,8 @@ export class ClaudeCodeRuntimeAdapter {
             : undefined;
         const event = mappedEvent.type === "message_delta"
           ? mappedEvent
+          : mappedEvent.type === "reasoning"
+            ? sanitizeReasoningEvent(mappedEvent)
           : mappedProviderType === "stream_event"
             ? outputStreamSanitizer.sanitizeChunk(
                 "provider_event:stream_event",
@@ -484,6 +524,7 @@ export class ClaudeCodeRuntimeAdapter {
         await flushPendingTextDelta();
         if (event.type === "final") {
           await flushHeldTextDelta();
+          await flushHeldReasoning();
         }
         if (event.type === "final") {
           const output = event.payload.output;
@@ -506,6 +547,7 @@ export class ClaudeCodeRuntimeAdapter {
 
       await flushPendingTextDelta();
       await flushHeldTextDelta();
+      await flushHeldReasoning();
       outputStreamSanitizer.discardAll();
       this.logStreamingTiming("return_outcome", {
         conversationKey: request.conversationKey,

--- a/src/local-pdf.ts
+++ b/src/local-pdf.ts
@@ -1,0 +1,176 @@
+import { open } from "node:fs/promises";
+import { dirname, isAbsolute, win32 } from "node:path";
+
+export type LocalPdfResource = Readonly<{
+  kind: "local_pdf";
+  sourceKey: string;
+  itemId: number;
+  contextItemId: number;
+  title: string;
+  name: string;
+  mimeType: "application/pdf";
+  absolutePath: string;
+}>;
+
+const LOCAL_PDF_POLICY = [
+  "Raw PDF transport policy for this turn:",
+  "Read each raw PDF from the exact current-turn path with Claude's native Read capability.",
+  "Do not substitute sibling attachments, earlier paths, Zotero indexed text, MinerU output, or another paper-reading route.",
+  "If an exact path cannot be read, report the failure instead of falling back.",
+].join("\n");
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function cleanLabel(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized || fallback;
+}
+
+function isHostAbsolutePath(value: string): boolean {
+  if (!value || value.includes("\0")) return false;
+  if (process.platform !== "win32") return isAbsolute(value);
+  const windowsPath = value.replace(/\//g, "\\");
+  return /^[A-Za-z]:\\/.test(windowsPath) || /^\\\\[^\\]+\\[^\\]+(?:\\|$)/.test(windowsPath);
+}
+
+function stringifyJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+export function collectLocalPdfs(runtimeRequest: unknown): readonly LocalPdfResource[] {
+  const request = asRecord(runtimeRequest);
+  if (!request || request.localDocuments === undefined) return [];
+  if (!Array.isArray(request.localDocuments)) {
+    throw new Error("Invalid local PDF resource batch.");
+  }
+
+  const resources: LocalPdfResource[] = [];
+  const sourceKeys = new Set<string>();
+  for (const candidate of request.localDocuments) {
+    const record = asRecord(candidate);
+    const itemId = asPositiveInteger(record?.itemId);
+    const contextItemId = asPositiveInteger(record?.contextItemId);
+    const sourceKey = typeof record?.sourceKey === "string" ? record.sourceKey : "";
+    const absolutePath = typeof record?.absolutePath === "string" ? record.absolutePath : "";
+    const title = cleanLabel(record?.title, "");
+    const name = cleanLabel(record?.name, "");
+    if (
+      !record ||
+      record.kind !== "local_pdf" ||
+      record.mimeType !== "application/pdf" ||
+      !itemId ||
+      !contextItemId ||
+      sourceKey !== `zotero-pdf:${itemId}:${contextItemId}` ||
+      !title ||
+      !name ||
+      !isHostAbsolutePath(absolutePath) ||
+      sourceKeys.has(sourceKey)
+    ) {
+      throw new Error("Invalid local PDF resource batch.");
+    }
+
+    sourceKeys.add(sourceKey);
+    resources.push(Object.freeze({
+      kind: "local_pdf",
+      sourceKey,
+      itemId,
+      contextItemId,
+      title,
+      name,
+      mimeType: "application/pdf",
+      absolutePath,
+    }));
+  }
+  return Object.freeze(resources);
+}
+
+export async function validateLocalPdfs(resources: readonly LocalPdfResource[]): Promise<void> {
+  for (const resource of resources) {
+    let file;
+    try {
+      file = await open(resource.absolutePath, "r");
+      const stat = await file.stat();
+      if (!stat.isFile() || stat.size < 5) throw new Error("not a non-empty regular file");
+      const signature = Buffer.alloc(5);
+      const { bytesRead } = await file.read(signature, 0, signature.length, 0);
+      if (bytesRead !== signature.length || signature.toString("ascii") !== "%PDF-") {
+        throw new Error("invalid PDF signature");
+      }
+    } catch {
+      throw new Error(`Selected raw PDF is missing, unreadable, or invalid (${resource.sourceKey}).`);
+    } finally {
+      await file?.close().catch(() => undefined);
+    }
+  }
+}
+
+export function localPdfDirectories(resources: readonly LocalPdfResource[]): string[] {
+  const directories = resources.map((resource) =>
+    process.platform === "win32"
+      ? win32.dirname(resource.absolutePath)
+      : dirname(resource.absolutePath),
+  );
+  return Array.from(new Set(directories));
+}
+
+export function renderLocalPdfPrompt(resources: readonly LocalPdfResource[]): string {
+  if (!resources.length) return "";
+  return [
+    "Raw PDFs explicitly selected for this turn:",
+    ...resources.map((resource, index) =>
+      `${index + 1}. ${stringifyJson({
+        sourceKey: resource.sourceKey,
+        itemId: resource.itemId,
+        contextItemId: resource.contextItemId,
+        title: resource.title,
+        name: resource.name,
+        absolutePath: resource.absolutePath,
+      })}`,
+    ),
+    "The ordered list above is authoritative.",
+    LOCAL_PDF_POLICY,
+  ].join("\n");
+}
+
+export function sanitizeLocalPdfOutput<T>(value: T, resources: readonly LocalPdfResource[]): T {
+  if (!resources.length) return value;
+  const replacements = resources.flatMap((resource) => {
+    const escaped = stringifyJson(resource.absolutePath).slice(1, -1);
+    const replacement = `[local-pdf-path:${resource.sourceKey}]`;
+    return Array.from(new Set([resource.absolutePath, escaped]))
+      .filter(Boolean)
+      .map((pattern) => ({ pattern, replacement }));
+  }).sort((left, right) => right.pattern.length - left.pattern.length);
+
+  const visit = (entry: unknown): unknown => {
+    if (typeof entry === "string") {
+      return replacements.reduce(
+        (text, replacement) => text.split(replacement.pattern).join(replacement.replacement),
+        entry,
+      );
+    }
+    if (Array.isArray(entry)) return entry.map(visit);
+    const record = asRecord(entry);
+    if (!record) return entry;
+    return Object.fromEntries(
+      Object.entries(record)
+        .filter(([key]) => key !== "sessionId" && key !== "session_id")
+        .map(([key, child]) => [key, visit(child)]),
+    );
+  };
+
+  return visit(value) as T;
+}

--- a/src/local-pdf.ts
+++ b/src/local-pdf.ts
@@ -50,6 +50,33 @@ function stringifyJson(value: unknown): string {
     .replace(/\u2029/g, "\\u2029");
 }
 
+type LocalPdfOutputReplacement = Readonly<{
+  pattern: string;
+  replacement: string;
+}>;
+
+function buildLocalPdfOutputReplacements(
+  resources: readonly LocalPdfResource[],
+): LocalPdfOutputReplacement[] {
+  return resources.flatMap((resource) => {
+    const escaped = stringifyJson(resource.absolutePath).slice(1, -1);
+    const replacement = `[local-pdf-path:${resource.sourceKey}]`;
+    return Array.from(new Set([resource.absolutePath, escaped]))
+      .filter(Boolean)
+      .map((pattern) => ({ pattern, replacement }));
+  }).sort((left, right) => right.pattern.length - left.pattern.length);
+}
+
+function replaceLocalPdfOutputPatterns(
+  value: string,
+  replacements: readonly LocalPdfOutputReplacement[],
+): string {
+  return replacements.reduce(
+    (text, replacement) => text.split(replacement.pattern).join(replacement.replacement),
+    value,
+  );
+}
+
 export function collectLocalPdfs(runtimeRequest: unknown): readonly LocalPdfResource[] {
   const request = asRecord(runtimeRequest);
   if (!request || request.localDocuments === undefined) return [];
@@ -145,22 +172,96 @@ export function renderLocalPdfPrompt(resources: readonly LocalPdfResource[]): st
   ].join("\n");
 }
 
+/**
+ * Holds only a suffix that can still become a selected local PDF path. SDK text
+ * deltas are separated by raw provider events, so complete paths cannot be
+ * safely redacted by treating each event as an independent string.
+ */
+export class LocalPdfOutputStreamSanitizer {
+  private readonly replacements: readonly LocalPdfOutputReplacement[];
+  private readonly pendingByChannel = new Map<
+    string,
+    { text: string; replacement: string }
+  >();
+
+  constructor(resources: readonly LocalPdfResource[]) {
+    this.replacements = buildLocalPdfOutputReplacements(resources);
+  }
+
+  pushText(channel: string, chunk: string): string {
+    if (!this.replacements.length || !chunk) return chunk;
+    const previous = this.pendingByChannel.get(channel);
+    const redacted = replaceLocalPdfOutputPatterns(
+      `${previous?.text || ""}${chunk}`,
+      this.replacements,
+    );
+    let pending:
+      | { length: number; replacement: string }
+      | undefined;
+    for (const replacement of this.replacements) {
+      const maximumLength = Math.min(
+        redacted.length,
+        replacement.pattern.length - 1,
+      );
+      for (let length = maximumLength; length > 0; length -= 1) {
+        if (
+          length > (pending?.length || 0) &&
+          redacted.endsWith(replacement.pattern.slice(0, length))
+        ) {
+          pending = { length, replacement: replacement.replacement };
+          break;
+        }
+      }
+    }
+    if (!pending) {
+      this.pendingByChannel.delete(channel);
+      return redacted;
+    }
+    this.pendingByChannel.set(channel, {
+      text: redacted.slice(-pending.length),
+      replacement: pending.replacement,
+    });
+    return redacted.slice(0, -pending.length);
+  }
+
+  sanitizeChunk<T>(channel: string, value: T): T {
+    if (!this.replacements.length) return value;
+    const visit = (entry: unknown, path: readonly (string | number)[]): unknown => {
+      if (typeof entry === "string") {
+        return this.pushText(`${channel}:${stringifyJson(path)}`, entry);
+      }
+      if (Array.isArray(entry)) {
+        return entry.map((child, index) => visit(child, [...path, index]));
+      }
+      const record = asRecord(entry);
+      if (!record) return entry;
+      return Object.fromEntries(
+        Object.entries(record)
+          .filter(([key]) => key !== "sessionId" && key !== "session_id")
+          .map(([key, child]) => [key, visit(child, [...path, key])]),
+      );
+    };
+    return visit(value, []) as T;
+  }
+
+  flushText(channel: string): string {
+    const pending = this.pendingByChannel.get(channel);
+    this.pendingByChannel.delete(channel);
+    return pending?.replacement || "";
+  }
+
+  discardAll(): void {
+    this.pendingByChannel.clear();
+  }
+}
+
 export function sanitizeLocalPdfOutput<T>(value: T, resources: readonly LocalPdfResource[]): T {
   if (!resources.length) return value;
-  const replacements = resources.flatMap((resource) => {
-    const escaped = stringifyJson(resource.absolutePath).slice(1, -1);
-    const replacement = `[local-pdf-path:${resource.sourceKey}]`;
-    return Array.from(new Set([resource.absolutePath, escaped]))
-      .filter(Boolean)
-      .map((pattern) => ({ pattern, replacement }));
-  }).sort((left, right) => right.pattern.length - left.pattern.length);
+  const replacements = buildLocalPdfOutputReplacements(resources);
 
   const visit = (entry: unknown): unknown => {
     if (typeof entry === "string") {
-      return replacements.reduce(
-        (text, replacement) => text.split(replacement.pattern).join(replacement.replacement),
-        entry,
-      );
+      return replaceLocalPdfOutputPatterns(entry, replacements);
     }
     if (Array.isArray(entry)) return entry.map(visit);
     const record = asRecord(entry);

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -1,4 +1,10 @@
-import type { Query, PermissionMode, SDKUserMessage, SettingSource } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  HookCallbackMatcher,
+  PermissionMode,
+  Query,
+  SDKUserMessage,
+  SettingSource,
+} from "@anthropic-ai/claude-agent-sdk";
 import { readFile } from "node:fs/promises";
 import { mkdirSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
@@ -10,6 +16,7 @@ import type { PermissionResult } from "../permissions/permission-store.js";
 import {
   collectLocalPdfs,
   localPdfDirectories,
+  type LocalPdfResource,
   renderLocalPdfPrompt,
   validateLocalPdfs,
 } from "../local-pdf.js";
@@ -194,6 +201,7 @@ type RuntimeRequestShape = {
 type CompactTurnOptions = {
   metadata: Record<string, unknown>;
   autoCompactNeeded: boolean;
+  persistUsageSnapshot?: boolean;
 };
 
 const RUNTIME_EFFORT_DESCENDING: RuntimeEffortLevel[] = ["max", "xhigh", "high", "medium", "low"];
@@ -510,11 +518,18 @@ function buildPromptText(
 ): string {
   const trimmedUserMessage = userMessage.trim();
   const localPdfs = collectLocalPdfs(runtimeRequest);
+  const includeFallbackHistory = metadata?.claudeResumeFallbackHistory === true;
   if (/^\/compact(?:\s|$)/i.test(trimmedUserMessage)) return "/compact";
-  if (trimmedUserMessage.startsWith("/") && !localPdfs.length) return trimmedUserMessage;
+  if (
+    trimmedUserMessage.startsWith("/") &&
+    !localPdfs.length &&
+    !includeFallbackHistory
+  ) {
+    return trimmedUserMessage;
+  }
   const lines: string[] = [trimmedUserMessage];
   if (!runtimeRequest) return lines.join("\n\n");
-  if (metadata?.claudeResumeFallbackHistory === true) {
+  if (includeFallbackHistory) {
     lines.push(...formatFallbackHistory(runtimeRequest));
   }
   const selectedTexts = Array.isArray(runtimeRequest.selectedTexts)
@@ -648,6 +663,37 @@ function mergeAllowedTools(requestAllowedTools: string[] | undefined, defaultAll
     if (normalized && !BLOCKED_ALLOWED_TOOLS.has(normalized)) merged.add(normalized);
   }
   return merged.size > 0 ? Array.from(merged) : undefined;
+}
+
+function buildLocalPdfReadHooks(
+  resources: readonly LocalPdfResource[],
+): { PreToolUse: HookCallbackMatcher[] } | undefined {
+  if (!resources.length) return undefined;
+  const selectedPaths = new Set(resources.map((resource) => resource.absolutePath));
+  return {
+    PreToolUse: [{
+      matcher: "Read",
+      hooks: [async (input) => {
+        if (input.hook_event_name !== "PreToolUse" || input.tool_name !== "Read") {
+          return { continue: true };
+        }
+        const toolInput = asRecord(input.tool_input);
+        const filePath = typeof toolInput?.file_path === "string"
+          ? toolInput.file_path
+          : "";
+        const allowed = Boolean(filePath && selectedPaths.has(filePath));
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: allowed ? "allow" : "deny",
+            permissionDecisionReason: allowed
+              ? "This exact PDF was selected for the current turn."
+              : "Raw PDF turns may read only exact PDF paths selected for the current turn.",
+          },
+        };
+      }],
+    }],
+  };
 }
 function isRuntimeEffortLevel(value: unknown): value is RuntimeEffortLevel {
   return value === "low" || value === "medium" || value === "high" || value === "xhigh" || value === "max";
@@ -985,8 +1031,14 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
   async startTurn(request: RuntimeTurnRequest): Promise<RuntimeTurnStream> {
     const metadata = parseMetadata(request.metadata, this.options);
     const localPdfs = collectLocalPdfs(toRuntimeRequest(request, metadata));
-    if (localPdfs.length && /^\/compact(?:\s|$)/i.test(request.userMessage.trim())) {
+    const isCompactTurn = /^\/compact(?:\s|$)/i.test(request.userMessage.trim());
+    if (localPdfs.length && isCompactTurn) {
       throw new Error("Cannot compact a raw PDF turn. Send the PDF request as a normal message.");
+    }
+    if (metadata.claudeResumeFallbackHistory === true && isCompactTurn) {
+      throw new Error(
+        "Cannot compact while Claude continuity is being rebuilt. Send a normal message first.",
+      );
     }
     await validateLocalPdfs(localPdfs);
     const probeId = typeof metadata.retentionProbeId === "string" ? metadata.retentionProbeId : undefined;
@@ -1030,7 +1082,11 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       const stream = await this.startColdTurn({
         ...request,
         providerSessionId: undefined,
-      }, { metadata, autoCompactNeeded: false });
+      }, {
+        metadata,
+        autoCompactNeeded: false,
+        persistUsageSnapshot: false,
+      });
       async function* withProfiling() {
         yield createProfilingEvent(request.conversationKey, "runtime.start_turn.local_pdf_ephemeral", hotEntrySnapshot);
         for await (const event of stream.events) yield event;
@@ -1569,6 +1625,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
         queryOptions,
         shouldInjectCompact || /^\/compact(?:\s|$)/i.test(request.userMessage.trim()),
         permissionEvents,
+        options?.persistUsageSnapshot !== false,
       ),
     };
   }
@@ -1582,6 +1639,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     initialQueryOptions: Record<string, unknown>,
     awaitingAutoCompact = false,
     permissionEvents = createProviderEventQueue(),
+    persistUsageSnapshot = true,
   ): AsyncIterable<ProviderEvent> {
     const hotRuntimePool = this.hotRuntimePool;
     const getLiveContextUsageSnapshot = this.getLiveContextUsageSnapshot.bind(this);
@@ -1673,7 +1731,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
                 if (event.type === "message_delta" || event.type === "tool_call" || event.type === "final") {
                   sawModelOutput = true;
                 }
-                if (event.type === "usage") {
+                if (event.type === "usage" && persistUsageSnapshot) {
                   const payload = event.payload as Record<string, unknown>;
                   const nextContextTokens = Number(payload.contextTokens);
                   const nextContextWindow = Number(payload.contextWindow);
@@ -1692,7 +1750,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
                     liveEntry.lastUsageSnapshot = merged;
                   }
                 }
-                if (event.type === "context_compacted") {
+                if (event.type === "context_compacted" && persistUsageSnapshot) {
                   const liveSnapshot = await getLiveContextUsageSnapshot(sdkStream);
                   if (liveSnapshot) {
                     const merged = mergeUsageSnapshot(request.conversationKey, liveSnapshot);
@@ -1957,6 +2015,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     const runtimeRequest = toRuntimeRequest(request, metadata);
     const localPdfs = collectLocalPdfs(runtimeRequest);
     const localDocumentDirectories = localPdfDirectories(localPdfs);
+    const localPdfReadHooks = buildLocalPdfReadHooks(localPdfs);
     const configuredAdditionalDirectories = (this.options.additionalDirectories || [])
       .map((entry) => entry.trim())
       .filter(Boolean);
@@ -2021,6 +2080,13 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       effortSuccessKey,
     });
     const effectivePermissionMode = permissionModeOverride ?? this.options.permissionMode;
+    const mergedAllowedTools = mergeAllowedTools(
+      request.allowedTools,
+      this.options.defaultAllowedTools,
+    );
+    const allowedTools = localPdfs.length
+      ? mergedAllowedTools?.filter((tool) => tool !== "Read")
+      : mergedAllowedTools;
     const canUseTool =
       effectivePermissionMode === "bypassPermissions"
         ? undefined
@@ -2070,12 +2136,8 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
         additionalDirectories: additionalDirectories.length
           ? additionalDirectories
           : undefined,
-        allowedTools: mergeAllowedTools(
-          request.allowedTools,
-          localPdfs.length
-            ? [...(this.options.defaultAllowedTools ?? []), "Read"]
-            : this.options.defaultAllowedTools,
-        ),
+        allowedTools: allowedTools?.length ? allowedTools : undefined,
+        hooks: localPdfReadHooks ?? metadata.hooks,
         mcpServers,
         settingSources: effectiveSettingSources,
         permissionMode: effectivePermissionMode,

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -7,6 +7,12 @@ import type { ClaudeCodeRuntimeClient, McpServerStatus, ProviderEvent, RuntimeTu
 import { mapSdkMessageToProviderEvents } from "../event-mapper/map-sdk-message.js";
 import { globalPermissionStore } from "../permissions/permission-store.js";
 import type { PermissionResult } from "../permissions/permission-store.js";
+import {
+  collectLocalPdfs,
+  localPdfDirectories,
+  renderLocalPdfPrompt,
+  validateLocalPdfs,
+} from "../local-pdf.js";
 import { getCachedModels, normalizeProviderModelName, resolveModelAlias, resolveModelWithCache, setCachedModels } from "./model-resolver.js";
 import { createHotRuntimeTurn, HotRuntimePool, type HotRuntimeEntry, type HotRuntimeTurn } from "./hotRuntimePool.js";
 
@@ -182,6 +188,7 @@ type RuntimeRequestShape = {
   screenshots?: unknown;
   history?: unknown;
   activeNoteContext?: unknown;
+  localDocuments?: unknown;
 };
 
 type CompactTurnOptions = {
@@ -502,8 +509,9 @@ function buildPromptText(
   metadata?: Record<string, unknown>,
 ): string {
   const trimmedUserMessage = userMessage.trim();
+  const localPdfs = collectLocalPdfs(runtimeRequest);
   if (/^\/compact(?:\s|$)/i.test(trimmedUserMessage)) return "/compact";
-  if (trimmedUserMessage.startsWith("/")) return trimmedUserMessage;
+  if (trimmedUserMessage.startsWith("/") && !localPdfs.length) return trimmedUserMessage;
   const lines: string[] = [trimmedUserMessage];
   if (!runtimeRequest) return lines.join("\n\n");
   if (metadata?.claudeResumeFallbackHistory === true) {
@@ -559,6 +567,7 @@ function buildPromptText(
       lines.push("Active note context:", noteTitle ? `- Title: ${noteTitle}` : "- Title: (untitled)", noteText ? `- Content:\n${noteText}` : "");
     }
   }
+  if (localPdfs.length) lines.push(renderLocalPdfPrompt(localPdfs));
   return lines.filter(Boolean).join("\n\n");
 }
 async function buildPromptInput(request: RuntimeTurnRequest, metadata: Record<string, unknown>): Promise<string | AsyncIterable<SDKUserMessage>> {
@@ -750,6 +759,7 @@ function buildHotRuntimeSignature(
     model: requestedModel,
     effort: requestedEffort,
     cwd: typeof queryOptions.cwd === "string" && queryOptions.cwd.trim() ? queryOptions.cwd : null,
+    additionalDirectories: toStableStringList(queryOptions.additionalDirectories, true),
     settingSources: toStableStringList(queryOptions.settingSources),
     permissionMode:
       typeof queryOptions.permissionMode === "string" && queryOptions.permissionMode.trim()
@@ -955,6 +965,11 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
 
   async startTurn(request: RuntimeTurnRequest): Promise<RuntimeTurnStream> {
     const metadata = parseMetadata(request.metadata, this.options);
+    const localPdfs = collectLocalPdfs(toRuntimeRequest(request, metadata));
+    if (localPdfs.length && /^\/compact(?:\s|$)/i.test(request.userMessage.trim())) {
+      throw new Error("Cannot compact a raw PDF turn. Send the PDF request as a normal message.");
+    }
+    await validateLocalPdfs(localPdfs);
     const probeId = typeof metadata.retentionProbeId === "string" ? metadata.retentionProbeId : undefined;
     const hotEntry = this.hotRuntimePool.get(request.conversationKey);
     const forceFreshSession = metadata.forceFreshSession === true;
@@ -984,12 +999,25 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
           probeId,
         };
     const autoCompactNeeded =
+      localPdfs.length === 0 &&
       !/^\/compact(?:\s|$)/i.test(request.userMessage.trim()) &&
       shouldAutoCompact(
         metadata,
         this.usageSnapshots.get(request.conversationKey) ?? hotEntry?.lastUsageSnapshot,
       );
     const createProfilingEvent = this.createProfilingEvent.bind(this);
+    if (localPdfs.length) {
+      await this.invalidateHotRuntime(request.conversationKey);
+      const stream = await this.startColdTurn({
+        ...request,
+        providerSessionId: undefined,
+      }, { metadata, autoCompactNeeded: false });
+      async function* withProfiling() {
+        yield createProfilingEvent(request.conversationKey, "runtime.start_turn.local_pdf_ephemeral", hotEntrySnapshot);
+        for await (const event of stream.events) yield event;
+      }
+      return { ...stream, providerSessionId: undefined, events: withProfiling() };
+    }
     if (forceFreshSession) {
       await this.invalidateHotRuntime(request.conversationKey);
       const stream = await this.startColdTurn({
@@ -1907,6 +1935,19 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     const permissionModeOverride = parsePermissionModeOverride(metadata);
     const customInstruction = parseCustomInstruction(metadata);
     const effectiveCwd = this.resolveScopedCwd(request.metadata);
+    const runtimeRequest = toRuntimeRequest(request, metadata);
+    const localPdfs = collectLocalPdfs(runtimeRequest);
+    const localDocumentDirectories = localPdfDirectories(localPdfs);
+    const configuredAdditionalDirectories = (this.options.additionalDirectories || [])
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    const additionalDirectories = Array.from(
+      new Set(
+        localDocumentDirectories.length
+          ? localDocumentDirectories.filter(Boolean)
+          : configuredAdditionalDirectories,
+      ),
+    );
     const effectiveSettingSources = settingSourcesOverride ?? this.options.settingSources ?? ["user", "project", "local"];
     const mcpServers = normalizeMcpServers(request.mcpServers ?? rawRequestMetadata.mcpServers);
     const providerKey =
@@ -2007,20 +2048,28 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
         effortFallbackNotice,
         effort: resolvedEffort,
         cwd: effectiveCwd,
-        additionalDirectories: this.options.additionalDirectories,
-        allowedTools: mergeAllowedTools(request.allowedTools, this.options.defaultAllowedTools),
+        additionalDirectories: additionalDirectories.length
+          ? additionalDirectories
+          : undefined,
+        allowedTools: mergeAllowedTools(
+          request.allowedTools,
+          localPdfs.length
+            ? [...(this.options.defaultAllowedTools ?? []), "Read"]
+            : this.options.defaultAllowedTools,
+        ),
         mcpServers,
         settingSources: effectiveSettingSources,
         permissionMode: effectivePermissionMode,
         includePartialMessages: this.options.includePartialMessages,
         maxTurns: this.options.maxTurns,
-        continue: this.options.continue,
+        continue: localPdfs.length ? false : this.options.continue,
+        persistSession: localPdfs.length ? false : undefined,
         appendSystemPrompt: [
           this.options.appendSystemPrompt,
           customInstruction,
           this.options.appendSystemPrompt || customInstruction ? undefined : this.buildConfigSourcePrompt(effectiveSettingSources, effectiveCwd, metadata),
         ].filter((entry): entry is string => Boolean(entry && entry.trim())).join("\n\n") || undefined,
-        resume: providerSessionId,
+        resume: localPdfs.length ? undefined : providerSessionId,
         abortController: request.signal ? this.createAbortController(request.signal) : undefined,
         canUseTool,
       }).filter(([, value]) => value !== undefined),

--- a/src/providers/claude-agent-sdk-runtime-client.ts
+++ b/src/providers/claude-agent-sdk-runtime-client.ts
@@ -937,6 +937,25 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
     this.usageSnapshots.delete(conversationKey);
   }
 
+  private async invalidateHotRuntimePreservingMounts(
+    conversationKey: string,
+  ): Promise<void> {
+    const entry = this.hotRuntimePool.get(conversationKey);
+    if (!entry) {
+      this.usageSnapshots.delete(conversationKey);
+      return;
+    }
+    const preservedMounts = Array.from(entry.mounts);
+    await this.closeHotRuntime(entry);
+    this.hotRuntimePool.delete(conversationKey);
+    this.usageSnapshots.delete(conversationKey);
+    if (!preservedMounts.length) return;
+    const retainedEntry = this.hotRuntimePool.ensure(conversationKey);
+    for (const mountId of preservedMounts) {
+      retainedEntry.mounts.add(mountId);
+    }
+  }
+
   async invalidateAllHotRuntimes(): Promise<void> {
     const keys = Array.from(this.hotRuntimePool["entries"].keys()) as string[];
     for (const key of keys) {
@@ -1007,7 +1026,7 @@ export class ClaudeAgentSdkRuntimeClient implements ClaudeCodeRuntimeClient {
       );
     const createProfilingEvent = this.createProfilingEvent.bind(this);
     if (localPdfs.length) {
-      await this.invalidateHotRuntime(request.conversationKey);
+      await this.invalidateHotRuntimePreservingMounts(request.conversationKey);
       const stream = await this.startColdTurn({
         ...request,
         providerSessionId: undefined,

--- a/src/server/http-bridge.ts
+++ b/src/server/http-bridge.ts
@@ -299,7 +299,12 @@ export async function startHttpBridgeServer(
     try {
       const reqUrl = new URL(req.url || "/", `http://${host}:${port}`);
       if (req.method === "GET" && req.url === "/healthz") {
-        sendJson(res, 200, { ok: true, ts: Date.now() });
+        sendJson(res, 200, {
+          ok: true,
+          protocolVersion: 2,
+          capabilities: ["local_pdf_paths"],
+          ts: Date.now(),
+        });
         return;
       }
 

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ClaudeCodeRuntimeAdapter } from "../src/bridge/claude-code-runtime-adapter.js";
 import type { ClaudeCodeRuntimeClient, ProviderEvent } from "../src/runtime.js";
+import type { AgentEvent } from "../src/types.js";
 import { InMemorySessionMapper } from "../src/session-link/session-mapper.js";
 import { InMemoryTraceStore } from "../src/trace-store/trace-store.js";
 
@@ -108,6 +109,118 @@ describe("ClaudeCodeRuntimeAdapter", () => {
     const traces = await traceStore.list("conv-A");
     expect(traces).toHaveLength(3);
     expect(traces[0]?.runId).toBe("run-1");
+  });
+
+  it("keeps PDF turns ephemeral, redacts their path, and rebuilds continuity once", async () => {
+    const pdfPath = "/private/library/paper a.pdf";
+    const seenRequests: Array<{
+      providerSessionId?: string;
+      fallbackHistory?: unknown;
+    }> = [];
+    let callCount = 0;
+    const runtimeClient: ClaudeCodeRuntimeClient = {
+      async startTurn(request) {
+        callCount += 1;
+        seenRequests.push({
+          providerSessionId: request.providerSessionId,
+          fallbackHistory: request.metadata?.claudeResumeFallbackHistory,
+        });
+        if (callCount === 1) {
+          const split = Math.floor(pdfPath.length / 2);
+          return {
+            runId: "run-pdf",
+            providerSessionId: "ephemeral-session",
+            events: providerEvents([
+              {
+                type: "message_delta",
+                payload: { delta: `Read ${pdfPath.slice(0, split)}`, sessionId: "ephemeral-session" },
+              },
+              {
+                type: "message_delta",
+                payload: { delta: pdfPath.slice(split), sessionId: "ephemeral-session" },
+              },
+              {
+                type: "tool_call",
+                payload: {
+                  name: "Read",
+                  input: { file_path: pdfPath, session_id: "ephemeral-session" },
+                  sessionId: "ephemeral-session",
+                },
+              },
+              {
+                type: "final",
+                payload: { output: `Read ${pdfPath}`, sessionId: "ephemeral-session" },
+              },
+            ]),
+          };
+        }
+        return {
+          runId: "run-normal",
+          providerSessionId: "new-persistent-session",
+          events: providerEvents([
+            { type: "final", payload: { output: "continued" } },
+          ]),
+        };
+      },
+    };
+
+    const sessionMapper = new InMemorySessionMapper();
+    await sessionMapper.set("conv-pdf-continuity", "old-persistent-session");
+    const traceStore = new InMemoryTraceStore();
+    const adapter = new ClaudeCodeRuntimeAdapter({ runtimeClient, sessionMapper, traceStore });
+    const seenEvents: AgentEvent[] = [];
+
+    const pdfOutcome = await adapter.runTurn({
+      conversationKey: "conv-pdf-continuity",
+      userMessage: "read it",
+      providerSessionId: "old-persistent-session",
+      runtimeRequest: {
+        localDocuments: [{
+          kind: "local_pdf",
+          sourceKey: "zotero-pdf:10:20",
+          itemId: 10,
+          contextItemId: 20,
+          title: "Paper",
+          name: "paper a.pdf",
+          mimeType: "application/pdf",
+          absolutePath: pdfPath,
+        }],
+      },
+    }, {
+      onEvent(event) {
+        seenEvents.push(event);
+      },
+    });
+
+    expect(seenRequests[0]?.providerSessionId).toBeUndefined();
+    expect(pdfOutcome.providerSessionId).toBeUndefined();
+    expect(pdfOutcome.finalText).not.toContain(pdfPath);
+    expect(await sessionMapper.get("conv-pdf-continuity")).toBeUndefined();
+    expect(await sessionMapper.get("conv-pdf-continuity::local-pdf-history-gap")).toBe("1");
+    expect(JSON.stringify(seenEvents)).not.toContain(pdfPath);
+    const serializedTraces = JSON.stringify(await traceStore.list("conv-pdf-continuity"));
+    expect(serializedTraces).not.toContain(pdfPath);
+    expect(serializedTraces).not.toContain("ephemeral-session");
+
+    const normalOutcome = await adapter.runTurn({
+      conversationKey: "conv-pdf-continuity",
+      userMessage: "continue",
+      providerSessionId: "old-persistent-session",
+      runtimeRequest: {
+        history: [
+          { role: "user", content: "read it" },
+          { role: "assistant", content: "summary" },
+        ],
+      },
+    });
+
+    expect(seenRequests[1]).toEqual({
+      providerSessionId: undefined,
+      fallbackHistory: true,
+    });
+    expect(normalOutcome.providerSessionId).toBe("new-persistent-session");
+    expect(await sessionMapper.get("conv-pdf-continuity")).toBe("new-persistent-session");
+    expect(await sessionMapper.get("conv-pdf-continuity::local-pdf-history-gap")).toBeUndefined();
   });
 
   it("resumes the base conversation session when provider identity changes", async () => {

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -146,6 +146,14 @@ describe("ClaudeCodeRuntimeAdapter", () => {
                 payload: { delta: `Read ${firstPathChunk}`, sessionId: "ephemeral-session" },
               },
               {
+                type: "reasoning",
+                payload: {
+                  round: 1,
+                  details: firstPathChunk,
+                  sessionId: "ephemeral-session",
+                },
+              },
+              {
                 type: "provider_event",
                 payload: {
                   providerType: "stream_event",
@@ -156,6 +164,14 @@ describe("ClaudeCodeRuntimeAdapter", () => {
               {
                 type: "message_delta",
                 payload: { delta: secondPathChunk, sessionId: "ephemeral-session" },
+              },
+              {
+                type: "reasoning",
+                payload: {
+                  round: 1,
+                  details: secondPathChunk,
+                  sessionId: "ephemeral-session",
+                },
               },
               {
                 type: "tool_call",

--- a/tests/adapter.spec.ts
+++ b/tests/adapter.spec.ts
@@ -113,6 +113,9 @@ describe("ClaudeCodeRuntimeAdapter", () => {
 
   it("keeps PDF turns ephemeral, redacts their path, and rebuilds continuity once", async () => {
     const pdfPath = "/private/library/paper a.pdf";
+    const split = Math.floor(pdfPath.length / 2);
+    const firstPathChunk = pdfPath.slice(0, split);
+    const secondPathChunk = pdfPath.slice(split);
     const seenRequests: Array<{
       providerSessionId?: string;
       fallbackHistory?: unknown;
@@ -126,18 +129,33 @@ describe("ClaudeCodeRuntimeAdapter", () => {
           fallbackHistory: request.metadata?.claudeResumeFallbackHistory,
         });
         if (callCount === 1) {
-          const split = Math.floor(pdfPath.length / 2);
           return {
             runId: "run-pdf",
             providerSessionId: "ephemeral-session",
             events: providerEvents([
               {
-                type: "message_delta",
-                payload: { delta: `Read ${pdfPath.slice(0, split)}`, sessionId: "ephemeral-session" },
+                type: "provider_event",
+                payload: {
+                  providerType: "stream_event",
+                  sessionId: "ephemeral-session",
+                  payload: { event: { delta: { text: `Read ${firstPathChunk}` } } },
+                },
               },
               {
                 type: "message_delta",
-                payload: { delta: pdfPath.slice(split), sessionId: "ephemeral-session" },
+                payload: { delta: `Read ${firstPathChunk}`, sessionId: "ephemeral-session" },
+              },
+              {
+                type: "provider_event",
+                payload: {
+                  providerType: "stream_event",
+                  sessionId: "ephemeral-session",
+                  payload: { event: { delta: { text: secondPathChunk } } },
+                },
+              },
+              {
+                type: "message_delta",
+                payload: { delta: secondPathChunk, sessionId: "ephemeral-session" },
               },
               {
                 type: "tool_call",
@@ -175,6 +193,10 @@ describe("ClaudeCodeRuntimeAdapter", () => {
       userMessage: "read it",
       providerSessionId: "old-persistent-session",
       runtimeRequest: {
+        history: [
+          { role: "user", content: "earlier question" },
+          { role: "assistant", content: "earlier answer" },
+        ],
         localDocuments: [{
           kind: "local_pdf",
           sourceKey: "zotero-pdf:10:20",
@@ -192,14 +214,22 @@ describe("ClaudeCodeRuntimeAdapter", () => {
       },
     });
 
-    expect(seenRequests[0]?.providerSessionId).toBeUndefined();
+    expect(seenRequests[0]).toEqual({
+      providerSessionId: undefined,
+      fallbackHistory: true,
+    });
     expect(pdfOutcome.providerSessionId).toBeUndefined();
     expect(pdfOutcome.finalText).not.toContain(pdfPath);
     expect(await sessionMapper.get("conv-pdf-continuity")).toBeUndefined();
     expect(await sessionMapper.get("conv-pdf-continuity::local-pdf-history-gap")).toBe("1");
-    expect(JSON.stringify(seenEvents)).not.toContain(pdfPath);
+    const serializedEvents = JSON.stringify(seenEvents);
+    expect(serializedEvents).not.toContain(pdfPath);
+    expect(serializedEvents).not.toContain(firstPathChunk);
+    expect(serializedEvents).not.toContain(secondPathChunk);
     const serializedTraces = JSON.stringify(await traceStore.list("conv-pdf-continuity"));
     expect(serializedTraces).not.toContain(pdfPath);
+    expect(serializedTraces).not.toContain(firstPathChunk);
+    expect(serializedTraces).not.toContain(secondPathChunk);
     expect(serializedTraces).not.toContain("ephemeral-session");
 
     const normalOutcome = await adapter.runTurn({

--- a/tests/http-bridge.spec.ts
+++ b/tests/http-bridge.spec.ts
@@ -25,6 +25,32 @@ async function readNdjsonLines(response: Response): Promise<Array<Record<string,
 }
 
 describe("http bridge server", () => {
+  it("advertises local PDF path protocol support", async () => {
+    const runtimeClient: ClaudeCodeRuntimeClient = {
+      async startTurn() {
+        return { runId: "run-health", events: providerEvents([]) };
+      },
+    };
+    const base = new ClaudeCodeRuntimeAdapter({
+      runtimeClient,
+      sessionMapper: new InMemorySessionMapper(),
+    });
+    const server = await startHttpBridgeServer({
+      adapter: new Llm4ZoteroAgentBackendAdapter({ adapter: base }),
+    });
+
+    try {
+      const response = await fetch(`http://${server.host}:${server.port}/healthz`);
+      expect(await response.json()).toMatchObject({
+        ok: true,
+        protocolVersion: 2,
+        capabilities: ["local_pdf_paths"],
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("returns tool catalog from /tools", async () => {
     const runtimeClient: ClaudeCodeRuntimeClient = {
       async startTurn() {

--- a/tests/sdk-runtime-client.spec.ts
+++ b/tests/sdk-runtime-client.spec.ts
@@ -199,7 +199,7 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     expect(seenPrompt).toContain("normalizedName=drift");
   });
 
-  it("passes exact current-turn PDF paths and parent directories to Claude", async () => {
+  it("passes exact current-turn PDF paths and enforces path-scoped Read access", async () => {
     const firstPdf = await createPdfFile("paper a.pdf");
     const secondPdf = await createPdfFile("paper\nβ\u2028.pdf");
     let seenPrompt = "";
@@ -268,7 +268,39 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
       dirname(firstPdf),
       dirname(secondPdf),
     ]);
-    expect(seenOptions.allowedTools).toContain("Read");
+    expect(seenOptions.allowedTools).toBeUndefined();
+    const hooks = seenOptions.hooks as {
+      PreToolUse?: Array<{
+        matcher?: string;
+        hooks?: Array<(input: unknown, toolUseId: string | undefined, options: unknown) => Promise<unknown>>;
+      }>;
+    };
+    const readMatcher = hooks.PreToolUse?.[0];
+    const readHook = readMatcher?.hooks?.[0];
+    expect(readMatcher?.matcher).toBe("Read");
+    expect(readHook).toBeTypeOf("function");
+    await expect(readHook?.({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: firstPdf },
+      tool_use_id: "read-selected",
+    }, "read-selected", {})).resolves.toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+      },
+    });
+    await expect(readHook?.({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: join(dirname(firstPdf), "sibling.pdf") },
+      tool_use_id: "read-sibling",
+    }, "read-sibling", {})).resolves.toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+      },
+    });
     expect(seenOptions.persistSession).toBe(false);
     expect(seenOptions.resume).toBeUndefined();
     expect(seenOptions.continue).toBe(false);
@@ -292,7 +324,7 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     const stream = await runtime.startTurn({
       conversationKey: "conv-pdf-skill",
       userMessage: "/my-pdf-skill answer with my format",
-      allowedTools: ["Skill"],
+      allowedTools: ["Read", "Skill"],
       runtimeRequest: {
         localDocuments: [{
           kind: "local_pdf",
@@ -310,8 +342,81 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
 
     expect(seenPrompt).toContain("/my-pdf-skill answer with my format");
     expect(seenPrompt).toContain(pdfPath);
-    expect(seenOptions.allowedTools).toEqual(["Read", "Skill"]);
+    expect(seenOptions.allowedTools).toEqual(["Skill"]);
     expect(seenOptions.settingSources).toEqual(["user", "project", "local"]);
+  });
+
+  it("does not carry ephemeral PDF usage into auto-compaction", async () => {
+    const pdfPath = await createPdfFile();
+    const seenPrompts: string[] = [];
+    let queryCount = 0;
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl(args) {
+        queryCount += 1;
+        seenPrompts.push(typeof args.prompt === "string" ? args.prompt : "[stream]");
+        if (queryCount === 1) {
+          return makeStream([
+            {
+              type: "assistant",
+              session_id: "ephemeral-pdf-session",
+              message: {
+                content: [{ type: "text", text: "summary" }],
+                usage: { input_tokens: 90, output_tokens: 1 },
+              },
+            },
+            {
+              type: "result",
+              session_id: "ephemeral-pdf-session",
+              result: "summary",
+              is_error: false,
+              modelUsage: { sonnet: { contextWindow: 100 } },
+            },
+          ]);
+        }
+        return makeStream([
+          {
+            type: "result",
+            session_id: "persistent-session",
+            result: "follow-up answer",
+            is_error: false,
+          },
+        ]);
+      },
+    });
+
+    const pdfTurn = await runtime.startTurn({
+      conversationKey: "conv-pdf-usage",
+      userMessage: "read it",
+      metadata: {
+        claudeAutoCompactEligible: true,
+        claudeAutoCompactThresholdPercent: 80,
+      },
+      runtimeRequest: {
+        localDocuments: [{
+          kind: "local_pdf",
+          sourceKey: "zotero-pdf:10:20",
+          itemId: 10,
+          contextItemId: 20,
+          title: "Paper",
+          name: "paper.pdf",
+          mimeType: "application/pdf",
+          absolutePath: pdfPath,
+        }],
+      },
+    });
+    for await (const _event of pdfTurn.events) void _event;
+
+    const followUp = await runtime.startTurn({
+      conversationKey: "conv-pdf-usage",
+      userMessage: "keep this follow-up",
+      metadata: {
+        claudeAutoCompactEligible: true,
+        claudeAutoCompactThresholdPercent: 80,
+      },
+    });
+    for await (const _event of followUp.events) void _event;
+
+    expect(seenPrompts[1]).toBe("keep this follow-up");
   });
 
   it("rejects the whole malformed local PDF batch before SDK query", async () => {
@@ -801,6 +906,73 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     expect(String(fallbackPrompt)).toContain("old answer");
     expect(String(normalPrompt)).not.toContain("Local Zotero conversation history");
     expect(String(normalPrompt)).not.toContain("old answer");
+  });
+
+  it("preserves history-gap continuity across compact and skill commands", async () => {
+    const pdfPath = await createPdfFile();
+    const seenPrompts: string[] = [];
+    let queryCalls = 0;
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl(args) {
+        queryCalls += 1;
+        seenPrompts.push(typeof args.prompt === "string" ? args.prompt : "[stream]");
+        return makeStream([
+          {
+            type: "result",
+            session_id: `session-${queryCalls}`,
+            result: "ok",
+            is_error: false,
+          },
+        ]);
+      },
+    });
+    const sessionMapper = new InMemorySessionMapper();
+    const adapter = new ClaudeCodeRuntimeAdapter({
+      runtimeClient: runtime,
+      sessionMapper,
+    });
+
+    await adapter.runTurn({
+      conversationKey: "conv-gap-command",
+      userMessage: "read the selected PDF",
+      runtimeRequest: {
+        history: [{ role: "user", content: "earlier question" }],
+        localDocuments: [{
+          kind: "local_pdf",
+          sourceKey: "zotero-pdf:10:20",
+          itemId: 10,
+          contextItemId: 20,
+          title: "Paper",
+          name: "paper.pdf",
+          mimeType: "application/pdf",
+          absolutePath: pdfPath,
+        }],
+      },
+    });
+    expect(await sessionMapper.get("conv-gap-command::local-pdf-history-gap")).toBe("1");
+
+    const history = [
+      { role: "user", content: "read the selected PDF" },
+      { role: "assistant", content: "PDF summary" },
+    ];
+    await expect(adapter.runTurn({
+      conversationKey: "conv-gap-command",
+      userMessage: "/compact",
+      runtimeRequest: { history },
+    })).rejects.toThrow("Cannot compact while Claude continuity is being rebuilt");
+    expect(queryCalls).toBe(1);
+    expect(await sessionMapper.get("conv-gap-command::local-pdf-history-gap")).toBe("1");
+
+    await adapter.runTurn({
+      conversationKey: "conv-gap-command",
+      userMessage: "/my-skill compare the result",
+      runtimeRequest: { history },
+    });
+
+    expect(seenPrompts[1]).toMatch(/^\/my-skill compare the result/);
+    expect(seenPrompts[1]).toContain("Local Zotero conversation history");
+    expect(seenPrompts[1]).toContain("PDF summary");
+    expect(await sessionMapper.get("conv-gap-command::local-pdf-history-gap")).toBeUndefined();
   });
 
   it("adapter updates session mapper from streamed sessionId", async () => {

--- a/tests/sdk-runtime-client.spec.ts
+++ b/tests/sdk-runtime-client.spec.ts
@@ -975,13 +975,26 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     const runtime = new ClaudeAgentSdkRuntimeClient({
       queryImpl(args) {
         queryCount += 1;
+        const sessionId = `sess-${queryCount}`;
         seenDirectories.push(args.options.additionalDirectories);
         seenPrompts.push(typeof args.prompt === "string" ? args.prompt : "[stream]");
         seenPersistence.push(args.options.persistSession);
-        return makeStream([
-          { type: "system", session_id: `sess-${queryCount}`, subtype: "init" },
-          { type: "result", session_id: `sess-${queryCount}`, result: "ok", is_error: false },
-        ]);
+        if (typeof args.prompt === "string") {
+          return makeStream([
+            { type: "system", session_id: sessionId, subtype: "init" },
+            { type: "result", session_id: sessionId, result: "ok", is_error: false },
+          ]);
+        }
+        const prompt = args.prompt as AsyncIterable<unknown>;
+        return {
+          async *[Symbol.asyncIterator]() {
+            for await (const _message of prompt) {
+              yield { type: "system", session_id: sessionId, subtype: "init" };
+              yield { type: "result", session_id: sessionId, result: "ok", is_error: false };
+            }
+          },
+          close() {},
+        } as any;
       },
     });
     const document = (itemId: number, contextItemId: number, absolutePath: string) => ({
@@ -1014,7 +1027,15 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
       conversationKey: "conv-hot-pdf",
       userMessage: "continue without a PDF",
     });
-    for await (const _event of third.events) void _event;
+    const thirdTurnStages: string[] = [];
+    for await (const event of third.events) {
+      if (event.type !== "provider_event") continue;
+      const payload = event.payload as Record<string, unknown>;
+      const nested = payload.payload as Record<string, unknown> | undefined;
+      if (payload.providerType === "profiling" && typeof nested?.stage === "string") {
+        thirdTurnStages.push(nested.stage);
+      }
+    }
 
     expect(queryCount).toBe(3);
     expect(seenDirectories).toEqual([
@@ -1029,6 +1050,10 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     expect(seenPrompts[2]).not.toContain(firstPdf);
     expect(seenPrompts[2]).not.toContain(secondPdf);
     expect(seenPersistence).toEqual([false, false, undefined]);
+    expect(thirdTurnStages).toContain("runtime.start_turn.hot_entry_found");
+    const retainedEntry = (runtime as any).hotRuntimePool.get("conv-hot-pdf");
+    expect(Array.from(retainedEntry?.mounts || [])).toEqual(["mount-1"]);
+    await runtime.invalidateHotRuntime("conv-hot-pdf");
   });
 
 

--- a/tests/sdk-runtime-client.spec.ts
+++ b/tests/sdk-runtime-client.spec.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { ClaudeCodeRuntimeAdapter } from "../src/bridge/claude-code-runtime-adapter.js";
 import { ClaudeAgentSdkRuntimeClient } from "../src/providers/claude-agent-sdk-runtime-client.js";
 import { setCachedModels } from "../src/providers/model-resolver.js";
@@ -36,6 +39,22 @@ function makeModelProbe(models: unknown[] = []): any {
   };
 }
 
+const temporaryDirectories = new Set<string>();
+
+async function createPdfFile(name = "paper.pdf", contents = "%PDF-1.4\n% test\n"): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "cc-l4z-pdf-"));
+  temporaryDirectories.add(directory);
+  const path = join(directory, name);
+  await writeFile(path, contents);
+  return path;
+}
+
+function stringifyJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 async function nextEvent(
   iterator: AsyncIterator<any>,
   timeoutMs = 1_000,
@@ -52,7 +71,7 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
   const originalHome = process.env.HOME;
   const originalUserProfile = process.env.USERPROFILE;
 
-  afterEach(() => {
+  afterEach(async () => {
     if (originalHome === undefined) {
       delete process.env.HOME;
     } else {
@@ -64,6 +83,10 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
       process.env.USERPROFILE = originalUserProfile;
     }
     globalPermissionStore.cleanup();
+    await Promise.all(
+      Array.from(temporaryDirectories, (directory) => rm(directory, { recursive: true, force: true })),
+    );
+    temporaryDirectories.clear();
   });
 
   it("passes resume/allowedTools into query options and maps messages", async () => {
@@ -175,6 +198,192 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     expect(seenPrompt).toContain("Drift");
     expect(seenPrompt).toContain("normalizedName=drift");
   });
+
+  it("passes exact current-turn PDF paths and parent directories to Claude", async () => {
+    const firstPdf = await createPdfFile("paper a.pdf");
+    const secondPdf = await createPdfFile("paper\nβ\u2028.pdf");
+    let seenPrompt = "";
+    let seenOptions: Record<string, unknown> = {};
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      additionalDirectories: ["/legacy-root"],
+      queryImpl(args) {
+        seenPrompt = typeof args.prompt === "string" ? args.prompt : "";
+        seenOptions = args.options;
+        return makeStream([
+          { type: "system", session_id: "session-pdf", subtype: "init" },
+          { type: "result", session_id: "session-pdf", result: "ok", is_error: false },
+        ]);
+      },
+    });
+
+    const stream = await runtime.startTurn({
+      conversationKey: "conv-pdf",
+      userMessage: "compare them",
+      runtimeRequest: {
+        selectedPaperContexts: [{
+          itemId: 10,
+          contextItemId: 20,
+          title: "Legacy duplicate",
+          contentSourceMode: "pdf",
+        }],
+        localDocuments: [
+          {
+            kind: "local_pdf",
+            sourceKey: "zotero-pdf:10:20",
+            itemId: 10,
+            contextItemId: 20,
+            title: "Paper A",
+            name: "paper a.pdf",
+            mimeType: "application/pdf",
+            absolutePath: firstPdf,
+          },
+          {
+            kind: "local_pdf",
+            sourceKey: "zotero-pdf:11:21",
+            itemId: 11,
+            contextItemId: 21,
+            title: "Paper B",
+            name: "paper β.pdf",
+            mimeType: "application/pdf",
+            absolutePath: secondPdf,
+          },
+        ],
+      },
+    });
+    for await (const _event of stream.events) {
+      // Drain.
+    }
+
+    expect(seenPrompt).toContain("zotero-pdf:10:20");
+    expect(seenPrompt).toContain(`"absolutePath":${stringifyJson(firstPdf)}`);
+    expect(seenPrompt).toContain("zotero-pdf:11:21");
+    expect(seenPrompt).toContain(`"absolutePath":${stringifyJson(secondPdf)}`);
+    expect(seenPrompt).not.toContain(`"absolutePath":"${secondPdf}"`);
+    expect(seenPrompt).toContain("\\u2028");
+    expect(seenPrompt).toContain("Do not substitute sibling attachments");
+    expect(seenPrompt.trim()).toMatch(
+      /Raw PDF transport policy[\s\S]*instead of falling back\.$/,
+    );
+    expect(seenOptions.additionalDirectories).toEqual([
+      dirname(firstPdf),
+      dirname(secondPdf),
+    ]);
+    expect(seenOptions.allowedTools).toContain("Read");
+    expect(seenOptions.persistSession).toBe(false);
+    expect(seenOptions.resume).toBeUndefined();
+    expect(seenOptions.continue).toBe(false);
+    expect(stream.providerSessionId).toBeUndefined();
+  });
+
+  it("keeps an explicitly invoked skill on a PDF turn", async () => {
+    const pdfPath = await createPdfFile();
+    let seenPrompt = "";
+    let seenOptions: Record<string, unknown> = {};
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl(args) {
+        seenPrompt = typeof args.prompt === "string" ? args.prompt : "";
+        seenOptions = args.options;
+        return makeStream([
+          { type: "result", session_id: "session-skill", result: "ok", is_error: false },
+        ]);
+      },
+    });
+
+    const stream = await runtime.startTurn({
+      conversationKey: "conv-pdf-skill",
+      userMessage: "/my-pdf-skill answer with my format",
+      allowedTools: ["Skill"],
+      runtimeRequest: {
+        localDocuments: [{
+          kind: "local_pdf",
+          sourceKey: "zotero-pdf:10:20",
+          itemId: 10,
+          contextItemId: 20,
+          title: "Paper",
+          name: "paper.pdf",
+          mimeType: "application/pdf",
+          absolutePath: pdfPath,
+        }],
+      },
+    });
+    for await (const _event of stream.events) void _event;
+
+    expect(seenPrompt).toContain("/my-pdf-skill answer with my format");
+    expect(seenPrompt).toContain(pdfPath);
+    expect(seenOptions.allowedTools).toEqual(["Read", "Skill"]);
+    expect(seenOptions.settingSources).toEqual(["user", "project", "local"]);
+  });
+
+  it("rejects the whole malformed local PDF batch before SDK query", async () => {
+    let queryCalls = 0;
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl() {
+        queryCalls += 1;
+        return makeStream([]);
+      },
+    });
+
+    await expect(runtime.startTurn({
+      conversationKey: "conv-invalid-pdf",
+      userMessage: "read it",
+      runtimeRequest: {
+        localDocuments: [{
+          kind: "local_pdf",
+          sourceKey: "zotero-pdf:10:999",
+          itemId: 10,
+          contextItemId: 20,
+          title: "Wrong identity",
+          name: "paper.pdf",
+          mimeType: "application/pdf",
+          absolutePath: "/papers/paper.pdf",
+        }],
+      },
+    })).rejects.toThrow("Invalid local PDF resource batch");
+    expect(queryCalls).toBe(0);
+  });
+
+  it("rejects an invalid file atomically before SDK query", async () => {
+    const validPdf = await createPdfFile("valid.pdf");
+    const invalidPdf = await createPdfFile("invalid.pdf", "not a PDF");
+    let queryCalls = 0;
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl() {
+        queryCalls += 1;
+        return makeStream([]);
+      },
+    });
+
+    await expect(runtime.startTurn({
+      conversationKey: "conv-invalid-file",
+      userMessage: "compare",
+      runtimeRequest: {
+        localDocuments: [
+          {
+            kind: "local_pdf",
+            sourceKey: "zotero-pdf:10:20",
+            itemId: 10,
+            contextItemId: 20,
+            title: "Valid",
+            name: "valid.pdf",
+            mimeType: "application/pdf",
+            absolutePath: validPdf,
+          },
+          {
+            kind: "local_pdf",
+            sourceKey: "zotero-pdf:11:21",
+            itemId: 11,
+            contextItemId: 21,
+            title: "Invalid",
+            name: "invalid.pdf",
+            mimeType: "application/pdf",
+            absolutePath: invalidPdf,
+          },
+        ],
+      },
+    })).rejects.toThrow("zotero-pdf:11:21");
+    expect(queryCalls).toBe(0);
+  });
+
 
   it("does not request live context usage after normal final results", async () => {
     let contextUsageCalls = 0;
@@ -755,6 +964,73 @@ describe("ClaudeAgentSdkRuntimeClient", () => {
     expect(queryCount).toBe(2);
     expect(seenResumes).toEqual([undefined, "sess-hot-rebuild"]);
   });
+
+  it("uses a fresh ephemeral query for every PDF turn", async () => {
+    const firstPdf = await createPdfFile("paper.pdf");
+    const secondPdf = await createPdfFile("paper.pdf");
+    let queryCount = 0;
+    const seenDirectories: unknown[] = [];
+    const seenPrompts: string[] = [];
+    const seenPersistence: unknown[] = [];
+    const runtime = new ClaudeAgentSdkRuntimeClient({
+      queryImpl(args) {
+        queryCount += 1;
+        seenDirectories.push(args.options.additionalDirectories);
+        seenPrompts.push(typeof args.prompt === "string" ? args.prompt : "[stream]");
+        seenPersistence.push(args.options.persistSession);
+        return makeStream([
+          { type: "system", session_id: `sess-${queryCount}`, subtype: "init" },
+          { type: "result", session_id: `sess-${queryCount}`, result: "ok", is_error: false },
+        ]);
+      },
+    });
+    const document = (itemId: number, contextItemId: number, absolutePath: string) => ({
+      kind: "local_pdf",
+      sourceKey: `zotero-pdf:${itemId}:${contextItemId}`,
+      itemId,
+      contextItemId,
+      title: "Paper",
+      name: "paper.pdf",
+      mimeType: "application/pdf",
+      absolutePath,
+    });
+
+    await runtime.retainHotRuntime({ conversationKey: "conv-hot-pdf", userMessage: "" }, "mount-1");
+    const first = await runtime.startTurn({
+      conversationKey: "conv-hot-pdf",
+      userMessage: "read A",
+      runtimeRequest: { localDocuments: [document(10, 20, firstPdf)] },
+    });
+    for await (const _event of first.events) void _event;
+
+    const second = await runtime.startTurn({
+      conversationKey: "conv-hot-pdf",
+      userMessage: "read B",
+      runtimeRequest: { localDocuments: [document(11, 21, secondPdf)] },
+    });
+    for await (const _event of second.events) void _event;
+
+    const third = await runtime.startTurn({
+      conversationKey: "conv-hot-pdf",
+      userMessage: "continue without a PDF",
+    });
+    for await (const _event of third.events) void _event;
+
+    expect(queryCount).toBe(3);
+    expect(seenDirectories).toEqual([
+      [dirname(firstPdf)],
+      [dirname(secondPdf)],
+      undefined,
+    ]);
+    expect(seenPrompts[0]).toContain(firstPdf);
+    expect(seenPrompts[0]).not.toContain(secondPdf);
+    expect(seenPrompts[1]).toContain(secondPdf);
+    expect(seenPrompts[1]).not.toContain(firstPdf);
+    expect(seenPrompts[2]).not.toContain(firstPdf);
+    expect(seenPrompts[2]).not.toContain(secondPdf);
+    expect(seenPersistence).toEqual([false, false, undefined]);
+  });
+
 
   it("rebuilds retained hot runtime when MCP server config changes", async () => {
     let queryCount = 0;


### PR DESCRIPTION
## Summary

This PR adds raw PDF support to the Claude Code bridge.

Claude can now read the exact PDFs selected in llm-for-zotero through its native `Read` capability, without substituting indexed text, MinerU output, sibling attachments, or another paper-reading route.

main repo branch: https://github.com/yilewang/llm-for-zotero/pull/312 

## Changes

- Accept and validate ordered `local_pdf` resources supplied through `runtimeRequest.localDocuments`.
- Verify each resource’s identity, absolute path, readability, and PDF signature before invoking Claude.
- Reject the entire document batch when any selected PDF is malformed, missing, unreadable, or invalid.
- Give Claude access only to the parent directories of the PDFs selected for the current turn.
- Enable the native `Read` capability for PDF turns while preserving explicitly invoked skills.
- Run every PDF request in a fresh, non-persistent Claude session without resume, continue, hot-runtime reuse, or automatic compaction.
- Rebuild conversation continuity from local Zotero history on the next non-PDF turn, then resume normal session persistence.
- Redact local PDF paths and ephemeral session identifiers from streamed events, final output, errors, and persisted traces.
- Advertise bridge protocol version 2 and the `local_pdf_paths` capability through `/healthz`.
- Preserve compatibility with existing non-PDF requests because the new behavior is activated only when local PDF resources are present.

## Compatibility

An adapter update is required only for Claude Code raw PDF support.

When no raw PDF is selected, llm-for-zotero does not perform the new capability check and continues sending the existing non-PDF request shape.

If a user selects raw PDF mode while running an older bridge, llm-for-zotero fails before sending the document and asks the user to update and restart the bridge.

## Verification

- `npm test` — 82 tests passed across 13 test files.
- `npm run build` — TypeScript build passed.


<img width="526" height="298" alt="image" src="https://github.com/user-attachments/assets/596abe26-a842-4912-bd89-2ac9b80b878a" />
